### PR TITLE
ci: add CI workflow to build debug APK and detect patch drift

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -1,0 +1,97 @@
+name: Build Debug APK
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'patches/**'
+      - 'patch.sh'
+      - 'generate-patches.sh'
+  pull_request:
+    paths:
+      - 'patches/**'
+      - 'patch.sh'
+      - 'generate-patches.sh'
+
+env:
+  SOURCE_APK_URL: https://github.com/Producdevity/gamehub-lite/releases/download/v5.1.0-patch/GameHub-5.1.0.apk
+  SOURCE_APK_MD5: 42db81116bf3c74e52e6f6afb4ec9f91
+  APKTOOL_VERSION: "2.10.0"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install apktool
+        run: |
+          wget -q "https://github.com/iBotPeaches/Apktool/releases/download/v${APKTOOL_VERSION}/apktool_${APKTOOL_VERSION}.jar" \
+            -O /usr/local/bin/apktool.jar
+          # Simple wrapper script instead of relying on upstream master branch
+          cat > /usr/local/bin/apktool << 'WRAPPER'
+          #!/bin/bash
+          exec java -jar /usr/local/bin/apktool.jar "$@"
+          WRAPPER
+          chmod +x /usr/local/bin/apktool
+
+      - name: Download source APK
+        run: |
+          mkdir -p apk
+          wget -q "$SOURCE_APK_URL" -O apk/GameHub-5.1.0.apk
+
+          md5=$(md5sum apk/GameHub-5.1.0.apk | awk '{print $1}')
+          if [ "$md5" != "$SOURCE_APK_MD5" ]; then
+            echo "::error::MD5 mismatch: expected $SOURCE_APK_MD5, got $md5"
+            exit 1
+          fi
+          echo "MD5 verified: $md5"
+
+      - name: Build debug APK
+        run: ./patch.sh
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: GameHub-Lite-debug
+          path: output/GameHub-Lite.apk
+          retention-days: 30
+
+      # Regenerate patches from the built APK and compare against repo.
+      # Detects patches that apply with fuzz/offset but aren't canonical.
+      # If drifted, uploads refreshed patches as a downloadable artifact.
+      - name: Refresh patches from built APK
+        id: refresh
+        run: |
+          cp -r patches/ /tmp/repo-patches/
+
+          ./generate-patches.sh apk/GameHub-5.1.0.apk output/GameHub-Lite.apk
+
+          if diff -rq /tmp/repo-patches/diffs/ patches/diffs/ > /dev/null 2>&1 && \
+             diff -q /tmp/repo-patches/files_to_patch.txt patches/files_to_patch.txt > /dev/null 2>&1 && \
+             diff -q /tmp/repo-patches/files_to_add.txt patches/files_to_add.txt > /dev/null 2>&1 && \
+             diff -q /tmp/repo-patches/files_to_delete.txt patches/files_to_delete.txt > /dev/null 2>&1; then
+            echo "status=clean" >> "$GITHUB_OUTPUT"
+            echo "Patches are canonical - no drift detected"
+          else
+            echo "status=drifted" >> "$GITHUB_OUTPUT"
+            echo "::warning::Patches have drifted from canonical form. Download the refreshed-patches artifact to update them."
+            echo ""
+            echo "=== Changed files ==="
+            diff -rq /tmp/repo-patches/ patches/ 2>/dev/null || true
+          fi
+
+      - name: Upload refreshed patches
+        if: steps.refresh.outputs.status == 'drifted'
+        uses: actions/upload-artifact@v4
+        with:
+          name: refreshed-patches
+          path: patches/
+          retention-days: 7

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -8,11 +8,13 @@ on:
       - 'patches/**'
       - 'patch.sh'
       - 'generate-patches.sh'
+      - '.github/workflows/build-debug.yml'
   pull_request:
     paths:
       - 'patches/**'
       - 'patch.sh'
       - 'generate-patches.sh'
+      - '.github/workflows/build-debug.yml'
 
 env:
   SOURCE_APK_URL: https://github.com/Producdevity/gamehub-lite/releases/download/v5.1.0-patch/GameHub-5.1.0.apk


### PR DESCRIPTION
Builds a debug-signed APK on pushes to master and PRs that touch patch files. 
Downloads source APK from GitHub Releases, runs patch.sh, and uploads the built APK as an artifact.

Also regenerates patches from the built APK to detect drift, patches that apply with fuzz/offset but aren't canonical. Uploads refreshed patches as a downloadable artifact when drift is detected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to build a debug APK from a provided source APK, verify its integrity, and publish the debug build as a downloadable artifact.
  * Automatically regenerates and compares patches; flags patch drift, emits a warning, and uploads refreshed patches when differences are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->