### PR TITLE
feat: add Component Manager and BCI launcher button

### DIFF
--- a/extension/ComponentManagerActivity.java
+++ b/extension/ComponentManagerActivity.java
@@ -1,0 +1,251 @@
+package app.revanced.extension.gamehub;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
+import android.provider.OpenableColumns;
+import android.util.Log;
+import android.view.Gravity;
+import android.widget.ArrayAdapter;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Component Manager Activity — injected into GameHub's dex via ReVanced extension.
+ *
+ * <p>Two-level ListView UI:
+ * <ol>
+ *   <li>Component list — shows all subdirs of {@code getFilesDir()/usr/home/components/}.
+ *       Appends {@code [-> filename]} for any component that has been previously injected.</li>
+ *   <li>Options menu (per component) — Inject file / Backup / Back</li>
+ * </ol>
+ *
+ * <p>Injected filenames are persisted in SharedPreferences ({@code "bh_injected"}) so the
+ * label survives app restarts.</p>
+ *
+ * <p>Must be registered in AndroidManifest.xml (done by the resource patch).</p>
+ */
+@SuppressWarnings("unused")
+public class ComponentManagerActivity extends Activity {
+
+    private static final String TAG = "BannerHub";
+    private static final int REQUEST_CODE_PICK_WCP = 1001;
+    private static final String PREFS_INJECTED = "bh_injected";
+
+    private File componentsDir;
+    private SharedPreferences injectedPrefs;
+    private String selectedComponent;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        componentsDir = new File(getFilesDir(), "usr/home/components");
+        injectedPrefs = getSharedPreferences(PREFS_INJECTED, MODE_PRIVATE);
+        showComponents();
+    }
+
+    // ── Screen: component list ────────────────────────────────────────────────
+
+    private void showComponents() {
+        List<String> rows = new ArrayList<>();
+        if (componentsDir.isDirectory()) {
+            File[] dirs = componentsDir.listFiles(File::isDirectory);
+            if (dirs != null) {
+                Arrays.sort(dirs);
+                for (File d : dirs) {
+                    String name = d.getName();
+                    String injected = injectedPrefs.getString(name, null);
+                    rows.add(injected != null ? name + " [-> " + injected + "]" : name);
+                }
+            }
+        }
+        if (rows.isEmpty()) rows.add("(no components found)");
+
+        LinearLayout root = buildRoot();
+        ListView listView = buildList(root, rows);
+        setContentView(root);
+
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            String raw = rows.get(position);
+            if (raw.equals("(no components found)")) return;
+            // Strip "[-> filename]" suffix to recover the bare component name
+            int bracket = raw.indexOf(" [-> ");
+            selectedComponent = bracket >= 0 ? raw.substring(0, bracket) : raw;
+            showOptions();
+        });
+    }
+
+    // ── Screen: per-component options ─────────────────────────────────────────
+
+    private void showOptions() {
+        List<String> options = new ArrayList<>();
+        options.add("Inject file");
+        options.add("Backup");
+        options.add("Back");
+
+        LinearLayout root = buildRoot();
+
+        TextView subtitle = new TextView(this);
+        subtitle.setText(selectedComponent);
+        subtitle.setTextSize(14f);
+        subtitle.setPadding(0, 0, 0, 24);
+        root.addView(subtitle);
+
+        ListView listView = buildList(root, options);
+        setContentView(root);
+
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            switch (position) {
+                case 0: openFilePicker(); break;
+                case 1: backupComponent(selectedComponent); break;
+                case 2: showComponents(); break;
+            }
+        });
+    }
+
+    // ── File injection ─────────────────────────────────────────────────────────
+
+    private void openFilePicker() {
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        startActivityForResult(intent, REQUEST_CODE_PICK_WCP);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != REQUEST_CODE_PICK_WCP || resultCode != RESULT_OK
+                || data == null || data.getData() == null) return;
+
+        Uri uri = data.getData();
+        File destDir = new File(componentsDir, selectedComponent);
+        final String componentName = selectedComponent;
+
+        Handler uiHandler = new Handler(Looper.getMainLooper());
+        new Thread(() -> {
+            try {
+                WcpExtractor.extract(getContentResolver(), uri, destDir);
+                String filename = getFileName(uri);
+                if (filename != null) {
+                    injectedPrefs.edit().putString(componentName, filename).apply();
+                }
+                uiHandler.post(() -> {
+                    Toast.makeText(this, "Injected successfully", Toast.LENGTH_SHORT).show();
+                    showComponents();
+                });
+            } catch (Throwable t) {
+                Log.e(TAG, "Extraction failed", t);
+                String msg = t.getMessage() != null ? t.getMessage() : t.getClass().getSimpleName();
+                uiHandler.post(() ->
+                        Toast.makeText(this, "Inject failed: " + msg, Toast.LENGTH_LONG).show());
+            }
+        }).start();
+    }
+
+    private String getFileName(Uri uri) {
+        try (Cursor cursor = getContentResolver().query(
+                uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                return cursor.getString(0);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "getFileName failed", e);
+        }
+        return null;
+    }
+
+    // ── Backup ────────────────────────────────────────────────────────────────
+
+    private void backupComponent(String name) {
+        File src = new File(componentsDir, name);
+        if (!src.isDirectory()) {
+            Toast.makeText(this, "Component directory not found", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        File backupRoot = new File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                "BannerHub/" + name);
+        backupRoot.mkdirs();
+
+        Handler uiHandler = new Handler(Looper.getMainLooper());
+        new Thread(() -> {
+            try {
+                copyDir(src, backupRoot);
+                uiHandler.post(() ->
+                        Toast.makeText(this, "Backed up to Downloads/BannerHub/" + name,
+                                Toast.LENGTH_SHORT).show());
+            } catch (Exception e) {
+                Log.e(TAG, "Backup failed", e);
+                uiHandler.post(() ->
+                        Toast.makeText(this, "Backup failed: " + e.getMessage(),
+                                Toast.LENGTH_SHORT).show());
+            }
+        }).start();
+    }
+
+    private static void copyDir(File src, File dst) throws Exception {
+        dst.mkdirs();
+        File[] files = src.listFiles();
+        if (files == null) return;
+        byte[] buf = new byte[8192];
+        for (File f : files) {
+            if (f.isDirectory()) {
+                copyDir(f, new File(dst, f.getName()));
+            } else {
+                try (InputStream in = new FileInputStream(f);
+                     OutputStream out = new FileOutputStream(new File(dst, f.getName()))) {
+                    int n;
+                    while ((n = in.read(buf)) > 0) out.write(buf, 0, n);
+                }
+            }
+        }
+    }
+
+    // ── UI helpers ────────────────────────────────────────────────────────────
+
+    /** Returns a root LinearLayout with the "Banners Component Injector" title pre-added. */
+    private LinearLayout buildRoot() {
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setPadding(48, 48, 48, 48);
+
+        TextView title = new TextView(this);
+        title.setText("Banners Component Injector");
+        title.setTextSize(20f);
+        title.setGravity(Gravity.CENTER);
+        title.setPadding(0, 0, 0, 24);
+        root.addView(title);
+
+        return root;
+    }
+
+    /** Adds a full-height ListView backed by {@code items} to {@code root} and returns it. */
+    private ListView buildList(LinearLayout root, List<String> items) {
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(
+                this, android.R.layout.simple_list_item_1, items);
+        ListView listView = new ListView(this);
+        listView.setAdapter(adapter);
+        root.addView(listView, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f));
+        return listView;
+    }
+}

--- a/extension/ComponentManagerHelper.java
+++ b/extension/ComponentManagerHelper.java
@@ -1,0 +1,135 @@
+package app.revanced.extension.gamehub;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.util.Log;
+import android.widget.Toast;
+
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+/**
+ * Static helpers called from smali code injected into GameHub Lite 5.1.4.
+ *
+ * <p>All methods are called from GameHub's own bytecode, so they use reflection
+ * for any GameHub-internal classes.</p>
+ *
+ * <p>MenuItem constructor in 5.1.4:
+ * {@code <init>(int id, int iconRes, String name, String rightContent, int mask,
+ * DefaultConstructorMarker)}</p>
+ */
+@SuppressWarnings("unused")
+public final class ComponentManagerHelper {
+
+    private static final String TAG = "BannerHub";
+    private static final int COMPONENTS_MENU_ID = 9;
+
+    private ComponentManagerHelper() {}
+
+    // ── Called from HomeLeftMenuDialog.Z0() ──────────────────────────────────
+
+    /**
+     * Appends a "Components" menu item to the sidebar item list.
+     *
+     * @param items the live List&lt;HomeLeftMenuDialog.MenuItem&gt; (this.m from Z0)
+     */
+    @SuppressWarnings("rawtypes")
+    public static void addComponentsMenuItem(List items) {
+        try {
+            android.content.Context ctx = (android.content.Context)
+                    Class.forName("android.app.ActivityThread")
+                            .getMethod("currentApplication")
+                            .invoke(null);
+
+            Class<?> menuItemClass = Class.forName(
+                    "com.xj.landscape.launcher.ui.menu.HomeLeftMenuDialog$MenuItem");
+            Class<?> markerClass = Class.forName(
+                    "kotlin.jvm.internal.DefaultConstructorMarker");
+
+            // 5.1.4 constructor: <init>(int id, int iconRes, String name,
+            //                           String rightContent, int mask, DefaultConstructorMarker)
+            Constructor<?> ctor = menuItemClass.getDeclaredConstructor(
+                    int.class, int.class, String.class, String.class,
+                    int.class, markerClass);
+            ctor.setAccessible(true);
+
+            int iconRes = ctx.getResources().getIdentifier(
+                    "menu_setting_normal", "drawable", ctx.getPackageName());
+
+            // mask=0x8: bit3 set → rightContent uses Kotlin default (null)
+            Object item = ctor.newInstance(
+                    COMPONENTS_MENU_ID, iconRes, "Components", null, 0x8, null);
+
+            //noinspection unchecked
+            items.add(item);
+        } catch (Exception e) {
+            Log.e(TAG, "addComponentsMenuItem failed", e);
+        }
+    }
+
+    // ── Called from HomeLeftMenuDialog$init$1$9$2.a(MenuItem) ────────────────
+
+    /**
+     * Intercepts the sidebar item click before the packed-switch runs.
+     *
+     * @param dialog    the HomeLeftMenuDialog fragment (this.a from the lambda)
+     * @param menuItem  the HomeLeftMenuDialog.MenuItem that was clicked (p1)
+     * @param activity  the hosting FragmentActivity (this.b from the lambda)
+     * @return true if we handled the click (ID=9), false to let the original switch run
+     */
+    public static boolean handleMenuItemClick(Object dialog, Object menuItem, Activity activity) {
+        try {
+            int id = (int) menuItem.getClass().getMethod("a").invoke(menuItem);
+            if (id != COMPONENTS_MENU_ID) return false;
+
+            // Dismiss the dialog first (same as the original packed-switch cases do)
+            dialog.getClass().getMethod("dismiss").invoke(dialog);
+
+            Intent intent = new Intent(activity, ComponentManagerActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            activity.startActivity(intent);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "handleMenuItemClick failed", e);
+            return false;
+        }
+    }
+
+    // ── Called from LandscapeLauncherMainActivity.initView() ─────────────────
+
+    /**
+     * Finds the BCI launcher button in the toolbar and attaches a click listener.
+     * Opens BannersComponentInjector if installed, or shows a toast if not.
+     *
+     * @param activity the LandscapeLauncherMainActivity instance
+     */
+    public static void setupBciButton(Activity activity) {
+        try {
+            int id = activity.getResources().getIdentifier(
+                    "iv_bci_launcher", "id", activity.getPackageName());
+            if (id == 0) return;
+
+            android.view.View btn = activity.findViewById(id);
+            if (btn == null) return;
+
+            btn.setOnClickListener(v -> {
+                try {
+                    android.content.pm.PackageManager pm = activity.getPackageManager();
+                    Intent intent = pm.getLaunchIntentForPackage("com.banner.inject");
+                    if (intent != null) {
+                        activity.startActivity(intent);
+                    } else {
+                        Toast.makeText(activity,
+                                "BannersComponentInjector not installed",
+                                Toast.LENGTH_SHORT).show();
+                    }
+                } catch (Exception e) {
+                    Toast.makeText(activity, "Error: " + e.getMessage(),
+                            Toast.LENGTH_SHORT).show();
+                }
+            });
+        } catch (Exception e) {
+            Log.e(TAG, "setupBciButton failed", e);
+        }
+    }
+}

--- a/extension/WcpExtractor.java
+++ b/extension/WcpExtractor.java
@@ -1,0 +1,236 @@
+package app.revanced.extension.gamehub;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+import android.util.Log;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Extracts WCP (zstd/XZ tar) and ZIP archives into a component directory.
+ *
+ * <p>Uses reflection for GameHub's obfuscated runtime classes:
+ * <ul>
+ *   <li>{@code com.github.luben.zstd.ZstdInputStreamNoFinalizer} (JNI, @Keep, not obfuscated)</li>
+ *   <li>{@code org.tukaani.xz.XZInputStream} (not obfuscated; constructor takes InputStream + int)</li>
+ *   <li>{@code org.apache.commons.compress.archivers.tar.TarArchiveInputStream}
+ *       (R8-obfuscated; {@code getNextTarEntry()} → {@code f()}; {@code read([BII)} kept)</li>
+ *   <li>{@code org.apache.commons.compress.archivers.tar.TarArchiveEntry}
+ *       ({@code getName()} → {@code p()} — ArchiveEntry interface is fully stripped by R8;
+ *       {@code isDirectory()} obfuscated — detect by {@code getName().endsWith("/")} instead)</li>
+ * </ul>
+ * </p>
+ */
+@SuppressWarnings("unused")
+public final class WcpExtractor {
+
+    private static final String TAG = "BannerHub";
+    private static final int BUF = 8192;
+
+    private WcpExtractor() {}
+
+    /**
+     * Main entry point. Clears destDir, auto-detects format from the first 4 bytes,
+     * then extracts ZIP/zstd-tar/XZ-tar accordingly.
+     */
+    public static void extract(ContentResolver cr, Uri uri, File destDir)
+            throws Exception {
+
+        InputStream raw = cr.openInputStream(uri);
+        if (raw == null) throw new IOException("Cannot open URI: " + uri);
+
+        try {
+            BufferedInputStream bis = new BufferedInputStream(raw);
+            try {
+                // Peek at 4-byte magic
+                bis.mark(4);
+                byte[] hdr = new byte[4];
+                int read = bis.read(hdr, 0, 4);
+                bis.reset();
+                if (read < 2) throw new IOException("File too short");
+
+                int b0 = hdr[0] & 0xFF, b1 = hdr[1] & 0xFF,
+                    b2 = hdr[2] & 0xFF, b3 = hdr[3] & 0xFF;
+
+                if (b0 == 0x50 && b1 == 0x4B) {
+                    // ZIP: PK magic
+                    clearDir(destDir); destDir.mkdirs();
+                    extractZip(bis, destDir);
+
+                } else if (b0 == 0x28 && b1 == 0xB5 && b2 == 0x2F && b3 == 0xFD) {
+                    // zstd tar
+                    clearDir(destDir); destDir.mkdirs();
+                    InputStream zstd = openZstd(bis);
+                    try {
+                        extractTar(zstd, destDir);
+                    } finally {
+                        zstd.close();
+                    }
+
+                } else if (b0 == 0xFD && b1 == 0x37 && b2 == 0x7A && b3 == 0x58) {
+                    // XZ tar
+                    clearDir(destDir); destDir.mkdirs();
+                    InputStream xz = openXz(bis);
+                    try {
+                        extractTar(xz, destDir);
+                    } finally {
+                        xz.close();
+                    }
+
+                } else {
+                    throw new Exception(String.format(
+                            "Unknown format (magic: %02X %02X %02X %02X)", b0, b1, b2, b3));
+                }
+            } finally {
+                bis.close();
+            }
+        } finally {
+            raw.close();
+        }
+    }
+
+    // ── Format openers via reflection ──────────────────────────────────────────
+
+    private static InputStream openZstd(InputStream in) throws Exception {
+        Class<?> cls = Class.forName("com.github.luben.zstd.ZstdInputStreamNoFinalizer");
+        Constructor<?> ctor = cls.getConstructor(InputStream.class);
+        return (InputStream) ctor.newInstance(in);
+    }
+
+    private static InputStream openXz(InputStream in) throws Exception {
+        Class<?> cls = Class.forName("org.tukaani.xz.XZInputStream");
+        Constructor<?> ctor = cls.getConstructor(InputStream.class, int.class);
+        return (InputStream) ctor.newInstance(in, -1); // -1 = unlimited memory
+    }
+
+    // ── ZIP extraction (flat — basename only) ─────────────────────────────────
+
+    private static void extractZip(InputStream in, File destDir) throws IOException {
+        byte[] buf = new byte[BUF];
+        ZipInputStream zip = new ZipInputStream(in);
+        ZipEntry entry;
+        while ((entry = zip.getNextEntry()) != null) {
+            if (entry.isDirectory()) {
+                zip.closeEntry();
+                continue;
+            }
+            // Flatten to basename
+            String name = new File(entry.getName()).getName();
+            File out = new File(destDir, name);
+            try (FileOutputStream fos = new FileOutputStream(out)) {
+                pipe(zip, fos, buf);
+            }
+            zip.closeEntry();
+        }
+        zip.close();
+    }
+
+    // ── Tar extraction ────────────────────────────────────────────────────────
+
+    /**
+     * Extracts a tar stream. Reads profile.json first pass to detect FEXCore
+     * (flattenToRoot=true). All other types preserve system32/syswow64 structure.
+     *
+     * <p>TarArchiveInputStream is obfuscated in GameHub's dex:
+     * getNextTarEntry() → s(); getName() kept; isDirectory() obfuscated → use endsWith("/").
+     */
+    private static void extractTar(InputStream in, File destDir) throws Exception {
+        Class<?> tarClass = Class.forName(
+                "org.apache.commons.compress.archivers.tar.TarArchiveInputStream");
+        Constructor<?> tarCtor = tarClass.getConstructor(InputStream.class);
+        Object tar = tarCtor.newInstance(in);
+
+        Method nextEntry = tarClass.getMethod("f"); // obfuscated getNextTarEntry() in 5.1.4
+        Method getName = null;                       // resolved on first entry — obfuscated to p() in 5.1.4
+
+        byte[] buf = new byte[BUF];
+        boolean flattenToRoot = false;
+
+        // First pass: scan for profile.json to detect component type
+        Object entry;
+        while ((entry = nextEntry.invoke(tar)) != null) {
+            if (getName == null) {
+                getName = entry.getClass().getMethod("p"); // obfuscated getName() in 5.1.4
+            }
+            String name = (String) getName.invoke(entry);
+            if (name == null) continue;
+
+            if (name.endsWith("/")) continue; // directory — skip
+
+            if (name.endsWith("profile.json")) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                pipeReflected(tar, baos, buf);
+                String json = baos.toString("UTF-8");
+                if (json.contains("FEXCore")) {
+                    flattenToRoot = true;
+                }
+                continue; // profile.json itself is metadata — don't extract
+            }
+
+            // Strip leading "./"
+            if (name.startsWith("./")) name = name.substring(2);
+            if (name.isEmpty()) continue;
+
+            File dest;
+            if (flattenToRoot) {
+                dest = new File(destDir, new File(name).getName());
+            } else {
+                dest = new File(destDir, name);
+                File parent = dest.getParentFile();
+                if (parent != null) parent.mkdirs();
+            }
+
+            try (FileOutputStream fos = new FileOutputStream(dest)) {
+                pipeReflected(tar, fos, buf);
+            }
+        }
+
+        // Close via reflection (close() is kept — not obfuscated)
+        tarClass.getMethod("close").invoke(tar);
+    }
+
+    // ── I/O helpers ───────────────────────────────────────────────────────────
+
+    private static void pipe(InputStream in, OutputStream out, byte[] buf) throws IOException {
+        int n;
+        while ((n = in.read(buf)) > 0) out.write(buf, 0, n);
+    }
+
+    /**
+     * Reads from a TarArchiveInputStream using the 3-arg read([BII)I method,
+     * which is confirmed present (not obfuscated) in 5.1.4's TarArchiveInputStream.
+     */
+    private static void pipeReflected(Object tar, OutputStream out, byte[] buf) throws Exception {
+        Method readMethod = tar.getClass().getMethod("read", byte[].class, int.class, int.class);
+        int n;
+        while ((n = (int) readMethod.invoke(tar, buf, 0, buf.length)) > 0) {
+            out.write(buf, 0, n);
+        }
+    }
+
+    // ── Directory utils ───────────────────────────────────────────────────────
+
+    /** Recursively deletes all contents of dir (keeps dir itself). */
+    static void clearDir(File dir) {
+        File[] files = dir.listFiles();
+        if (files == null) return;
+        for (File f : files) {
+            if (f.isDirectory()) {
+                clearDir(f);
+            }
+            if (!f.delete()) {
+                Log.w(TAG, "clearDir: failed to delete " + f.getAbsolutePath());
+            }
+        }
+    }
+}

--- a/patches/diffs/AndroidManifest.xml.patch
+++ b/patches/diffs/AndroidManifest.xml.patch
@@ -466,3 +466,7 @@
 +        </provider>
      </application>
  </manifest>
+@@ -467,3 +413,6 @@
++        <activity android:name="app.revanced.extension.gamehub.ComponentManagerActivity" android:label="Components" android:exported="false" android:screenOrientation="sensorLandscape" />
+     </application>
+ </manifest>

--- a/patches/diffs/res/layout/llauncher_activity_new_launcher_main.xml.patch
+++ b/patches/diffs/res/layout/llauncher_activity_new_launcher_main.xml.patch
@@ -1,8 +1,9 @@
 --- a/res/layout/llauncher_activity_new_launcher_main.xml
 +++ b/res/layout/llauncher_activity_new_launcher_main.xml
-@@ -13,9 +13,10 @@
+@@ -13,9 +13,11 @@
          <com.xj.user.view.UserAvatarView android:id="@id/right_user_avatar_view" android:padding="@dimen/mw_3dp" android:visibility="gone" android:layout_width="@dimen/mw_30dp" android:layout_height="@dimen/mw_30dp" />
          <com.xj.common.view.focus.focus.view.FocusableImageView android:id="@id/iv_search" android:padding="@dimen/mw_3dp" android:layout_width="@dimen/mw_30dp" android:layout_height="@dimen/mw_30dp" android:src="@drawable/llanuncher_ic_main_search" android:layout_marginStart="@dimen/mw_16dp" />
++        <com.xj.common.view.focus.focus.view.FocusableImageView android:id="@id/iv_bci_launcher" android:padding="@dimen/mw_3dp" android:layout_width="@dimen/mw_30dp" android:layout_height="@dimen/mw_30dp" android:src="@drawable/menu_setting_normal" android:layout_marginStart="@dimen/mw_16dp" />
          <com.xj.common.view.DownloadProgressIconView android:id="@id/iv_downloading" android:padding="@dimen/mw_3dp" android:visibility="gone" android:layout_width="@dimen/mw_30dp" android:layout_height="@dimen/mw_30dp" android:layout_marginStart="@dimen/mw_16dp" />
 -        <com.xj.common.view.focus.focus.view.FocusableImageView android:id="@id/iv_device_online" android:padding="@dimen/mw_3dp" android:layout_width="@dimen/mw_30dp" android:layout_height="@dimen/mw_30dp" android:src="@drawable/comm_ic_main_device_offline" android:layout_marginStart="@dimen/mw_16dp" />
 +        <com.xj.common.view.focus.focus.view.FocusableImageView android:id="@id/iv_device_online" android:padding="@dimen/mw_3dp" android:focusable="false" android:visibility="gone" android:clickable="false" android:layout_width="0.0dip" android:layout_height="0.0dip" android:src="@drawable/comm_ic_main_device_offline" android:layout_marginStart="0.0dip" />

--- a/patches/diffs/res/values/ids.xml.patch
+++ b/patches/diffs/res/values/ids.xml.patch
@@ -1,6 +1,6 @@
 --- a/res/values/ids.xml
 +++ b/res/values/ids.xml
-@@ -3338,4 +3338,10 @@
+@@ -3338,4 +3338,11 @@
      <item type="id" name="xy_together_max" />
      <item type="id" name="yesTv" />
      <item type="id" name="zh_bgImage" />
@@ -10,4 +10,5 @@
 +    <item type="id" name="tv_local_game_id" />
 +    <item type="id" name="ll_local_game_id_container" />
 +    <item type="id" name="btn_copy_local_game_id" />
++    <item type="id" name="iv_bci_launcher" />
  </resources>

--- a/patches/diffs/res/values/public.xml.patch
+++ b/patches/diffs/res/values/public.xml.patch
@@ -170,7 +170,7 @@
      <public type="font" name="d_din_pro_600_semibold" id="0x7f090000" />
      <public type="font" name="roboto_medium_numbers" id="0x7f090001" />
      <public type="id" name="ALT" id="0x7f0a0000" />
-@@ -15317,6 +15276,12 @@
+@@ -15317,6 +15276,13 @@
      <public type="id" name="yesTv" id="0x7f0a0e77" />
      <public type="id" name="zh_bgImage" id="0x7f0a0e78" />
      <public type="id" name="zoom" id="0x7f0a0e79" />
@@ -180,6 +180,7 @@
 +    <public type="id" name="tv_local_game_id" id="0x7f0a0e7d" />
 +    <public type="id" name="ll_local_game_id_container" id="0x7f0a0e7e" />
 +    <public type="id" name="btn_copy_local_game_id" id="0x7f0a0e7f" />
++    <public type="id" name="iv_bci_launcher" id="0x7f0a0e80" />
      <public type="integer" name="abc_config_activityDefaultDur" id="0x7f0b0000" />
      <public type="integer" name="abc_config_activityShortDur" id="0x7f0b0001" />
      <public type="integer" name="app_bar_elevation_anim_duration" id="0x7f0b0002" />

--- a/patches/diffs/smali_classes5/com/xj/landscape/launcher/ui/main/LandscapeLauncherMainActivity.smali.patch
+++ b/patches/diffs/smali_classes5/com/xj/landscape/launcher/ui/main/LandscapeLauncherMainActivity.smali.patch
@@ -71,5 +71,15 @@
 -    invoke-static/range {v0 .. v6}, Lcom/xj/common/utils/PermissionUtils;->J(Lcom/xj/common/utils/PermissionUtils;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
 -
      invoke-virtual/range {p0 .. p0}, Lcom/xj/landscape/launcher/ui/main/LandscapeLauncherMainActivity;->m2()V
- 
+
      invoke-virtual/range {p0 .. p0}, Lcom/xj/landscape/launcher/ui/main/LandscapeLauncherMainActivity;->X2()V
+@@ -3649,5 +3591,8 @@
+
+     invoke-virtual/range {p0 .. p0}, Lcom/xj/landscape/launcher/ui/main/LandscapeLauncherMainActivity;->X2()V
+
++    move-object/from16 v0, p0
++
++    invoke-static {v0}, Lapp/revanced/extension/gamehub/ComponentManagerHelper;->setupBciButton(Landroid/app/Activity;)V
++
+     return-void
+ .end method

--- a/patches/diffs/smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2.smali.patch
+++ b/patches/diffs/smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2.smali.patch
@@ -1,0 +1,23 @@
+--- a/smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2.smali
++++ b/smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2.smali
+@@ -54,6 +54,16 @@
+ .method public final a(Lcom/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$MenuItem;)V
+     .locals 4
+
++    iget-object v0, p0, Lcom/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2;->a:Lcom/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog;
++
++    iget-object v1, p0, Lcom/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2;->b:Landroidx/fragment/app/FragmentActivity;
++
++    invoke-static {v0, p1, v1}, Lapp/revanced/extension/gamehub/ComponentManagerHelper;->handleMenuItemClick(Ljava/lang/Object;Ljava/lang/Object;Landroid/app/Activity;)Z
++
++    move-result v0
++
++    if-eqz v0, :cond_bh_not_handled
++
++    return-void
++
++    :cond_bh_not_handled
++
+     const-string v0, "entity"
+
+     invoke-static {p1, v0}, Lkotlin/jvm/internal/Intrinsics;->g(Ljava/lang/Object;Ljava/lang/String;)V

--- a/patches/diffs/smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog.smali.patch
+++ b/patches/diffs/smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog.smali.patch
@@ -94,3 +94,10 @@
      new-instance v3, Lcom/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$MenuItem;
  
      sget v14, Lcom/xj/landscape/launcher/R$drawable;->menu_setting_normal:I
+@@ -1307,4 +1252,7 @@
+     invoke-interface {v2, v3}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
++    invoke-static {v2}, Lapp/revanced/extension/gamehub/ComponentManagerHelper;->addComponentsMenuItem(Ljava/util/List;)V
++
+     return-void
+ .end method

--- a/patches/files_to_add.txt
+++ b/patches/files_to_add.txt
@@ -2857,3 +2857,16 @@ smali_classes4/com/xj/winemu/PcEmuSetupDialog$1.smali
 smali_classes5/com/xj/cloud/ui/setting/CloudGameSettingDataHelper.smali
 smali_classes5/com/xj/landscape/launcher/ui/gamedetail/GameDetailActivity$CopyLocalGameIdClickListener.smali
 smali_classes5/com/xj/landscape/launcher/ui/gamedetail/GameVideoActivity$$ExternalSyntheticLambda0.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda7.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0.smali
+smali_classes11/app/revanced/extension/gamehub/ComponentManagerHelper.smali
+smali_classes11/app/revanced/extension/gamehub/WcpExtractor.smali

--- a/patches/files_to_patch.txt
+++ b/patches/files_to_patch.txt
@@ -183,6 +183,7 @@ smali_classes5/com/xj/landscape/launcher/ui/main/me/MyGamesView.smali
 smali_classes5/com/xj/landscape/launcher/ui/main/me/childlist/GameChildListView$loadData$1.smali
 smali_classes5/com/xj/landscape/launcher/ui/main/viewholders/PcEmulatorInfoViewHolder.smali
 smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog.smali
+smali_classes5/com/xj/landscape/launcher/ui/menu/HomeLeftMenuDialog$init$1$9$2.smali
 smali_classes5/com/xj/landscape/launcher/ui/setting/SettingMainActivity.smali
 smali_classes5/com/xj/landscape/launcher/ui/setting/tab/AboutSettingFragment.smali
 smali_classes5/com/xj/landscape/launcher/ui/setting/tab/HelpSettingFragment$initObserver$2.smali

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0.smali
@@ -1,0 +1,36 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/lang/Runnable;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final run()V
+    .locals 0
+
+    .line 0
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    invoke-virtual {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$onActivityResult$2$app-revanced-extension-gamehub-ComponentManagerActivity()V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1.smali
@@ -1,0 +1,42 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/lang/Runnable;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+.field public final synthetic f$1:Ljava/lang/String;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/lang/String;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iput-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;->f$1:Ljava/lang/String;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final run()V
+    .locals 1
+
+    .line 0
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;->f$1:Ljava/lang/String;
+
+    invoke-virtual {v0, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$onActivityResult$3$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/lang/String;)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2.smali
@@ -1,0 +1,42 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/lang/Runnable;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+.field public final synthetic f$1:Ljava/lang/String;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/lang/String;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iput-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;->f$1:Ljava/lang/String;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final run()V
+    .locals 1
+
+    .line 0
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;->f$1:Ljava/lang/String;
+
+    invoke-virtual {v0, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$backupComponent$5$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/lang/String;)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3.smali
@@ -1,0 +1,42 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/lang/Runnable;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+.field public final synthetic f$1:Ljava/lang/Exception;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/lang/Exception;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iput-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;->f$1:Ljava/lang/Exception;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final run()V
+    .locals 1
+
+    .line 0
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;->f$1:Ljava/lang/Exception;
+
+    invoke-virtual {v0, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$backupComponent$6$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/lang/Exception;)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4.smali
@@ -1,0 +1,60 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/lang/Runnable;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+.field public final synthetic f$1:Ljava/io/File;
+
+.field public final synthetic f$2:Ljava/io/File;
+
+.field public final synthetic f$3:Landroid/os/Handler;
+
+.field public final synthetic f$4:Ljava/lang/String;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/io/File;Ljava/io/File;Landroid/os/Handler;Ljava/lang/String;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iput-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$1:Ljava/io/File;
+
+    iput-object p3, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$2:Ljava/io/File;
+
+    iput-object p4, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$3:Landroid/os/Handler;
+
+    iput-object p5, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$4:Ljava/lang/String;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final run()V
+    .locals 4
+
+    .line 0
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iget-object v1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$1:Ljava/io/File;
+
+    iget-object v2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$2:Ljava/io/File;
+
+    iget-object v3, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$3:Landroid/os/Handler;
+
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;->f$4:Ljava/lang/String;
+
+    invoke-virtual {v0, v1, v2, v3, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$backupComponent$7$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/io/File;Ljava/io/File;Landroid/os/Handler;Ljava/lang/String;)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5.smali
@@ -1,0 +1,36 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Landroid/widget/AdapterView$OnItemClickListener;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final onItemClick(Landroid/widget/AdapterView;Landroid/view/View;IJ)V
+    .locals 0
+
+    .line 0
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    invoke-virtual/range {p0 .. p5}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$showOptions$1$app-revanced-extension-gamehub-ComponentManagerActivity(Landroid/widget/AdapterView;Landroid/view/View;IJ)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6.smali
@@ -1,0 +1,60 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/lang/Runnable;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+.field public final synthetic f$1:Landroid/net/Uri;
+
+.field public final synthetic f$2:Ljava/io/File;
+
+.field public final synthetic f$3:Ljava/lang/String;
+
+.field public final synthetic f$4:Landroid/os/Handler;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Landroid/net/Uri;Ljava/io/File;Ljava/lang/String;Landroid/os/Handler;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iput-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$1:Landroid/net/Uri;
+
+    iput-object p3, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$2:Ljava/io/File;
+
+    iput-object p4, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$3:Ljava/lang/String;
+
+    iput-object p5, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$4:Landroid/os/Handler;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final run()V
+    .locals 4
+
+    .line 0
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iget-object v1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$1:Landroid/net/Uri;
+
+    iget-object v2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$2:Ljava/io/File;
+
+    iget-object v3, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$3:Ljava/lang/String;
+
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;->f$4:Landroid/os/Handler;
+
+    invoke-virtual {v0, v1, v2, v3, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$onActivityResult$4$app-revanced-extension-gamehub-ComponentManagerActivity(Landroid/net/Uri;Ljava/io/File;Ljava/lang/String;Landroid/os/Handler;)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda7.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda7.smali
@@ -1,0 +1,30 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda7;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Ljava/io/FileFilter;
+
+
+# direct methods
+.method public synthetic constructor <init>()V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final accept(Ljava/io/File;)Z
+    .locals 0
+
+    .line 0
+    invoke-static {p1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->$r8$lambda$phMJnUSDNE1oaCR8Amcd4RFLhw0(Ljava/io/File;)Z
+
+    move-result p0
+
+    return p0
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8.smali
@@ -1,0 +1,50 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Landroid/widget/AdapterView$OnItemClickListener;
+
+
+# instance fields
+.field public final synthetic f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+.field public final synthetic f$1:Ljava/util/List;
+
+
+# direct methods
+.method public synthetic constructor <init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/util/List;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iput-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;->f$1:Ljava/util/List;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final onItemClick(Landroid/widget/AdapterView;Landroid/view/View;IJ)V
+    .locals 7
+
+    .line 0
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;->f$0:Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    iget-object v1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;->f$1:Ljava/util/List;
+
+    move-object v2, p1
+
+    move-object v3, p2
+
+    move v4, p3
+
+    move-wide v5, p4
+
+    invoke-virtual/range {v0 .. v6}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->lambda$showComponents$0$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/util/List;Landroid/widget/AdapterView;Landroid/view/View;IJ)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerActivity.smali
@@ -1,0 +1,1154 @@
+.class public Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+.super Landroid/app/Activity;
+.source "ComponentManagerActivity.java"
+
+
+# static fields
+.field private static final PREFS_INJECTED:Ljava/lang/String; = "bh_injected"
+
+.field private static final REQUEST_CODE_PICK_WCP:I = 0x3e9
+
+.field private static final TAG:Ljava/lang/String; = "BannerHub"
+
+
+# instance fields
+.field private componentsDir:Ljava/io/File;
+
+.field private injectedPrefs:Landroid/content/SharedPreferences;
+
+.field private selectedComponent:Ljava/lang/String;
+
+
+# direct methods
+.method public static synthetic $r8$lambda$phMJnUSDNE1oaCR8Amcd4RFLhw0(Ljava/io/File;)Z
+    .locals 0
+
+    invoke-virtual {p0}, Ljava/io/File;->isDirectory()Z
+
+    move-result p0
+
+    return p0
+.end method
+
+.method public constructor <init>()V
+    .locals 0
+
+    .line 46
+    invoke-direct {p0}, Landroid/app/Activity;-><init>()V
+
+    return-void
+.end method
+
+.method private backupComponent(Ljava/lang/String;)V
+    .locals 7
+
+    .line 178
+    new-instance v2, Ljava/io/File;
+
+    iget-object v0, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->componentsDir:Ljava/io/File;
+
+    invoke-direct {v2, v0, p1}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    .line 179
+    invoke-virtual {v2}, Ljava/io/File;->isDirectory()Z
+
+    move-result v0
+
+    if-nez v0, :cond_0
+
+    .line 180
+    const-string p1, "Component directory not found"
+
+    const/4 v0, 0x0
+
+    invoke-static {p0, p1, v0}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object p0
+
+    invoke-virtual {p0}, Landroid/widget/Toast;->show()V
+
+    return-void
+
+    .line 184
+    :cond_0
+    new-instance v3, Ljava/io/File;
+
+    sget-object v0, Landroid/os/Environment;->DIRECTORY_DOWNLOADS:Ljava/lang/String;
+
+    .line 185
+    invoke-static {v0}, Landroid/os/Environment;->getExternalStoragePublicDirectory(Ljava/lang/String;)Ljava/io/File;
+
+    move-result-object v0
+
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    const-string v4, "BannerHub/"
+
+    invoke-direct {v1, v4}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v1, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v1
+
+    invoke-virtual {v1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v1
+
+    invoke-direct {v3, v0, v1}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    .line 187
+    invoke-virtual {v3}, Ljava/io/File;->mkdirs()Z
+
+    .line 189
+    new-instance v4, Landroid/os/Handler;
+
+    invoke-static {}, Landroid/os/Looper;->getMainLooper()Landroid/os/Looper;
+
+    move-result-object v0
+
+    invoke-direct {v4, v0}, Landroid/os/Handler;-><init>(Landroid/os/Looper;)V
+
+    .line 190
+    new-instance v6, Ljava/lang/Thread;
+
+    new-instance v0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;
+
+    move-object v1, p0
+
+    move-object v5, p1
+
+    invoke-direct/range {v0 .. v5}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda4;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/io/File;Ljava/io/File;Landroid/os/Handler;Ljava/lang/String;)V
+
+    invoke-direct {v6, v0}, Ljava/lang/Thread;-><init>(Ljava/lang/Runnable;)V
+
+    .line 202
+    invoke-virtual {v6}, Ljava/lang/Thread;->start()V
+
+    return-void
+.end method
+
+.method private buildList(Landroid/widget/LinearLayout;Ljava/util/List;)Landroid/widget/ListView;
+    .locals 3
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "(",
+            "Landroid/widget/LinearLayout;",
+            "Ljava/util/List<",
+            "Ljava/lang/String;",
+            ">;)",
+            "Landroid/widget/ListView;"
+        }
+    .end annotation
+
+    .line 243
+    new-instance v0, Landroid/widget/ArrayAdapter;
+
+    const v1, 0x1090003
+
+    invoke-direct {v0, p0, v1, p2}, Landroid/widget/ArrayAdapter;-><init>(Landroid/content/Context;ILjava/util/List;)V
+
+    .line 245
+    new-instance p2, Landroid/widget/ListView;
+
+    invoke-direct {p2, p0}, Landroid/widget/ListView;-><init>(Landroid/content/Context;)V
+
+    .line 246
+    invoke-virtual {p2, v0}, Landroid/widget/ListView;->setAdapter(Landroid/widget/ListAdapter;)V
+
+    .line 247
+    new-instance p0, Landroid/widget/LinearLayout$LayoutParams;
+
+    const/4 v0, 0x0
+
+    const/high16 v1, 0x3f800000    # 1.0f
+
+    const/4 v2, -0x1
+
+    invoke-direct {p0, v2, v0, v1}, Landroid/widget/LinearLayout$LayoutParams;-><init>(IIF)V
+
+    invoke-virtual {p1, p2, p0}, Landroid/widget/LinearLayout;->addView(Landroid/view/View;Landroid/view/ViewGroup$LayoutParams;)V
+
+    return-object p2
+.end method
+
+.method private buildRoot()Landroid/widget/LinearLayout;
+    .locals 3
+
+    .line 227
+    new-instance v0, Landroid/widget/LinearLayout;
+
+    invoke-direct {v0, p0}, Landroid/widget/LinearLayout;-><init>(Landroid/content/Context;)V
+
+    const/4 v1, 0x1
+
+    .line 228
+    invoke-virtual {v0, v1}, Landroid/widget/LinearLayout;->setOrientation(I)V
+
+    const/16 v1, 0x30
+
+    .line 229
+    invoke-virtual {v0, v1, v1, v1, v1}, Landroid/widget/LinearLayout;->setPadding(IIII)V
+
+    .line 231
+    new-instance v1, Landroid/widget/TextView;
+
+    invoke-direct {v1, p0}, Landroid/widget/TextView;-><init>(Landroid/content/Context;)V
+
+    .line 232
+    const-string p0, "Banners Component Injector"
+
+    invoke-virtual {v1, p0}, Landroid/widget/TextView;->setText(Ljava/lang/CharSequence;)V
+
+    const/high16 p0, 0x41a00000    # 20.0f
+
+    .line 233
+    invoke-virtual {v1, p0}, Landroid/widget/TextView;->setTextSize(F)V
+
+    const/16 p0, 0x11
+
+    .line 234
+    invoke-virtual {v1, p0}, Landroid/widget/TextView;->setGravity(I)V
+
+    const/4 p0, 0x0
+
+    const/16 v2, 0x18
+
+    .line 235
+    invoke-virtual {v1, p0, p0, p0, v2}, Landroid/widget/TextView;->setPadding(IIII)V
+
+    .line 236
+    invoke-virtual {v0, v1}, Landroid/widget/LinearLayout;->addView(Landroid/view/View;)V
+
+    return-object v0
+.end method
+
+.method private static copyDir(Ljava/io/File;Ljava/io/File;)V
+    .locals 8
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 206
+    invoke-virtual {p1}, Ljava/io/File;->mkdirs()Z
+
+    .line 207
+    invoke-virtual {p0}, Ljava/io/File;->listFiles()[Ljava/io/File;
+
+    move-result-object p0
+
+    if-nez p0, :cond_0
+
+    goto :goto_5
+
+    :cond_0
+    const/16 v0, 0x2000
+
+    .line 209
+    new-array v0, v0, [B
+
+    .line 210
+    array-length v1, p0
+
+    const/4 v2, 0x0
+
+    move v3, v2
+
+    :goto_0
+    if-ge v3, v1, :cond_3
+
+    aget-object v4, p0, v3
+
+    .line 211
+    invoke-virtual {v4}, Ljava/io/File;->isDirectory()Z
+
+    move-result v5
+
+    if-eqz v5, :cond_1
+
+    .line 212
+    new-instance v5, Ljava/io/File;
+
+    invoke-virtual {v4}, Ljava/io/File;->getName()Ljava/lang/String;
+
+    move-result-object v6
+
+    invoke-direct {v5, p1, v6}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    invoke-static {v4, v5}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->copyDir(Ljava/io/File;Ljava/io/File;)V
+
+    goto :goto_2
+
+    .line 214
+    :cond_1
+    new-instance v5, Ljava/io/FileInputStream;
+
+    invoke-direct {v5, v4}, Ljava/io/FileInputStream;-><init>(Ljava/io/File;)V
+
+    .line 215
+    :try_start_0
+    new-instance v6, Ljava/io/FileOutputStream;
+
+    new-instance v7, Ljava/io/File;
+
+    invoke-virtual {v4}, Ljava/io/File;->getName()Ljava/lang/String;
+
+    move-result-object v4
+
+    invoke-direct {v7, p1, v4}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    invoke-direct {v6, v7}, Ljava/io/FileOutputStream;-><init>(Ljava/io/File;)V
+    :try_end_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_2
+
+    .line 217
+    :goto_1
+    :try_start_1
+    invoke-virtual {v5, v0}, Ljava/io/InputStream;->read([B)I
+
+    move-result v4
+
+    if-lez v4, :cond_2
+
+    invoke-virtual {v6, v0, v2, v4}, Ljava/io/OutputStream;->write([BII)V
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_0
+
+    goto :goto_1
+
+    .line 218
+    :cond_2
+    :try_start_2
+    invoke-virtual {v6}, Ljava/io/OutputStream;->close()V
+    :try_end_2
+    .catchall {:try_start_2 .. :try_end_2} :catchall_2
+
+    invoke-virtual {v5}, Ljava/io/InputStream;->close()V
+
+    :goto_2
+    add-int/lit8 v3, v3, 0x1
+
+    goto :goto_0
+
+    :catchall_0
+    move-exception p0
+
+    .line 214
+    :try_start_3
+    invoke-virtual {v6}, Ljava/io/OutputStream;->close()V
+    :try_end_3
+    .catchall {:try_start_3 .. :try_end_3} :catchall_1
+
+    goto :goto_3
+
+    :catchall_1
+    move-exception p1
+
+    :try_start_4
+    invoke-virtual {p0, p1}, Ljava/lang/Throwable;->addSuppressed(Ljava/lang/Throwable;)V
+
+    :goto_3
+    throw p0
+    :try_end_4
+    .catchall {:try_start_4 .. :try_end_4} :catchall_2
+
+    :catchall_2
+    move-exception p0
+
+    :try_start_5
+    invoke-virtual {v5}, Ljava/io/InputStream;->close()V
+    :try_end_5
+    .catchall {:try_start_5 .. :try_end_5} :catchall_3
+
+    goto :goto_4
+
+    :catchall_3
+    move-exception p1
+
+    invoke-virtual {p0, p1}, Ljava/lang/Throwable;->addSuppressed(Ljava/lang/Throwable;)V
+
+    :goto_4
+    throw p0
+
+    :cond_3
+    :goto_5
+    return-void
+.end method
+
+.method private getFileName(Landroid/net/Uri;)Ljava/lang/String;
+    .locals 7
+
+    .line 164
+    :try_start_0
+    invoke-virtual {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->getContentResolver()Landroid/content/ContentResolver;
+
+    move-result-object v0
+
+    const/4 p0, 0x1
+
+    new-array v2, p0, [Ljava/lang/String;
+
+    const-string p0, "_display_name"
+
+    const/4 v6, 0x0
+
+    aput-object p0, v2, v6
+
+    const/4 v4, 0x0
+
+    const/4 v5, 0x0
+
+    const/4 v3, 0x0
+
+    move-object v1, p1
+
+    invoke-virtual/range {v0 .. v5}, Landroid/content/ContentResolver;->query(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;
+
+    move-result-object p0
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    if-eqz p0, :cond_2
+
+    .line 166
+    :try_start_1
+    invoke-interface {p0}, Landroid/database/Cursor;->moveToFirst()Z
+
+    move-result p1
+
+    if-eqz p1, :cond_2
+
+    .line 167
+    invoke-interface {p0, v6}, Landroid/database/Cursor;->getString(I)Ljava/lang/String;
+
+    move-result-object p1
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_0
+
+    if-eqz p0, :cond_0
+
+    .line 169
+    :try_start_2
+    invoke-interface {p0}, Landroid/database/Cursor;->close()V
+    :try_end_2
+    .catch Ljava/lang/Exception; {:try_start_2 .. :try_end_2} :catch_0
+
+    :cond_0
+    return-object p1
+
+    :catchall_0
+    move-exception v0
+
+    move-object p1, v0
+
+    if-eqz p0, :cond_1
+
+    .line 164
+    :try_start_3
+    invoke-interface {p0}, Landroid/database/Cursor;->close()V
+    :try_end_3
+    .catchall {:try_start_3 .. :try_end_3} :catchall_1
+
+    goto :goto_0
+
+    :catchall_1
+    move-exception v0
+
+    move-object p0, v0
+
+    :try_start_4
+    invoke-virtual {p1, p0}, Ljava/lang/Throwable;->addSuppressed(Ljava/lang/Throwable;)V
+
+    :cond_1
+    :goto_0
+    throw p1
+
+    :cond_2
+    if-eqz p0, :cond_3
+
+    .line 169
+    invoke-interface {p0}, Landroid/database/Cursor;->close()V
+    :try_end_4
+    .catch Ljava/lang/Exception; {:try_start_4 .. :try_end_4} :catch_0
+
+    goto :goto_1
+
+    :catch_0
+    move-exception v0
+
+    move-object p0, v0
+
+    .line 170
+    const-string p1, "BannerHub"
+
+    const-string v0, "getFileName failed"
+
+    invoke-static {p1, v0, p0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    :cond_3
+    :goto_1
+    const/4 p0, 0x0
+
+    return-object p0
+.end method
+
+.method private openFilePicker()V
+    .locals 2
+
+    .line 126
+    new-instance v0, Landroid/content/Intent;
+
+    const-string v1, "android.intent.action.OPEN_DOCUMENT"
+
+    invoke-direct {v0, v1}, Landroid/content/Intent;-><init>(Ljava/lang/String;)V
+
+    .line 127
+    const-string v1, "android.intent.category.OPENABLE"
+
+    invoke-virtual {v0, v1}, Landroid/content/Intent;->addCategory(Ljava/lang/String;)Landroid/content/Intent;
+
+    .line 128
+    const-string v1, "*/*"
+
+    invoke-virtual {v0, v1}, Landroid/content/Intent;->setType(Ljava/lang/String;)Landroid/content/Intent;
+
+    const/16 v1, 0x3e9
+
+    .line 129
+    invoke-virtual {p0, v0, v1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->startActivityForResult(Landroid/content/Intent;I)V
+
+    return-void
+.end method
+
+.method private showComponents()V
+    .locals 7
+
+    .line 67
+    new-instance v0, Ljava/util/ArrayList;
+
+    invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
+
+    .line 68
+    iget-object v1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->componentsDir:Ljava/io/File;
+
+    invoke-virtual {v1}, Ljava/io/File;->isDirectory()Z
+
+    move-result v1
+
+    if-eqz v1, :cond_1
+
+    .line 69
+    iget-object v1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->componentsDir:Ljava/io/File;
+
+    new-instance v2, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda7;
+
+    invoke-direct {v2}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda7;-><init>()V
+
+    invoke-virtual {v1, v2}, Ljava/io/File;->listFiles(Ljava/io/FileFilter;)[Ljava/io/File;
+
+    move-result-object v1
+
+    if-eqz v1, :cond_1
+
+    .line 71
+    invoke-static {v1}, Ljava/util/Arrays;->sort([Ljava/lang/Object;)V
+
+    .line 72
+    array-length v2, v1
+
+    const/4 v3, 0x0
+
+    :goto_0
+    if-ge v3, v2, :cond_1
+
+    aget-object v4, v1, v3
+
+    .line 73
+    invoke-virtual {v4}, Ljava/io/File;->getName()Ljava/lang/String;
+
+    move-result-object v4
+
+    .line 74
+    iget-object v5, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->injectedPrefs:Landroid/content/SharedPreferences;
+
+    const/4 v6, 0x0
+
+    invoke-interface {v5, v4, v6}, Landroid/content/SharedPreferences;->getString(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object v5
+
+    if-eqz v5, :cond_0
+
+    .line 75
+    new-instance v6, Ljava/lang/StringBuilder;
+
+    invoke-direct {v6}, Ljava/lang/StringBuilder;-><init>()V
+
+    invoke-virtual {v6, v4}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v4
+
+    const-string v6, " [-> "
+
+    invoke-virtual {v4, v6}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v4
+
+    invoke-virtual {v4, v5}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v4
+
+    const-string v5, "]"
+
+    invoke-virtual {v4, v5}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v4
+
+    invoke-virtual {v4}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v4
+
+    :cond_0
+    invoke-interface {v0, v4}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
+    add-int/lit8 v3, v3, 0x1
+
+    goto :goto_0
+
+    .line 79
+    :cond_1
+    invoke-interface {v0}, Ljava/util/List;->isEmpty()Z
+
+    move-result v1
+
+    if-eqz v1, :cond_2
+
+    const-string v1, "(no components found)"
+
+    invoke-interface {v0, v1}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
+    .line 81
+    :cond_2
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->buildRoot()Landroid/widget/LinearLayout;
+
+    move-result-object v1
+
+    .line 82
+    invoke-direct {p0, v1, v0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->buildList(Landroid/widget/LinearLayout;Ljava/util/List;)Landroid/widget/ListView;
+
+    move-result-object v2
+
+    .line 83
+    invoke-virtual {p0, v1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->setContentView(Landroid/view/View;)V
+
+    .line 85
+    new-instance v1, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;
+
+    invoke-direct {v1, p0, v0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda8;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/util/List;)V
+
+    invoke-virtual {v2, v1}, Landroid/widget/ListView;->setOnItemClickListener(Landroid/widget/AdapterView$OnItemClickListener;)V
+
+    return-void
+.end method
+
+.method private showOptions()V
+    .locals 5
+
+    .line 98
+    new-instance v0, Ljava/util/ArrayList;
+
+    invoke-direct {v0}, Ljava/util/ArrayList;-><init>()V
+
+    .line 99
+    const-string v1, "Inject file"
+
+    invoke-interface {v0, v1}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
+    .line 100
+    const-string v1, "Backup"
+
+    invoke-interface {v0, v1}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
+    .line 101
+    const-string v1, "Back"
+
+    invoke-interface {v0, v1}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+
+    .line 103
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->buildRoot()Landroid/widget/LinearLayout;
+
+    move-result-object v1
+
+    .line 105
+    new-instance v2, Landroid/widget/TextView;
+
+    invoke-direct {v2, p0}, Landroid/widget/TextView;-><init>(Landroid/content/Context;)V
+
+    .line 106
+    iget-object v3, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->selectedComponent:Ljava/lang/String;
+
+    invoke-virtual {v2, v3}, Landroid/widget/TextView;->setText(Ljava/lang/CharSequence;)V
+
+    const/high16 v3, 0x41600000    # 14.0f
+
+    .line 107
+    invoke-virtual {v2, v3}, Landroid/widget/TextView;->setTextSize(F)V
+
+    const/4 v3, 0x0
+
+    const/16 v4, 0x18
+
+    .line 108
+    invoke-virtual {v2, v3, v3, v3, v4}, Landroid/widget/TextView;->setPadding(IIII)V
+
+    .line 109
+    invoke-virtual {v1, v2}, Landroid/widget/LinearLayout;->addView(Landroid/view/View;)V
+
+    .line 111
+    invoke-direct {p0, v1, v0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->buildList(Landroid/widget/LinearLayout;Ljava/util/List;)Landroid/widget/ListView;
+
+    move-result-object v0
+
+    .line 112
+    invoke-virtual {p0, v1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->setContentView(Landroid/view/View;)V
+
+    .line 114
+    new-instance v1, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5;
+
+    invoke-direct {v1, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda5;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;)V
+
+    invoke-virtual {v0, v1}, Landroid/widget/ListView;->setOnItemClickListener(Landroid/widget/AdapterView$OnItemClickListener;)V
+
+    return-void
+.end method
+
+
+# virtual methods
+.method synthetic lambda$backupComponent$5$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/lang/String;)V
+    .locals 2
+
+    .line 194
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    const-string v1, "Backed up to Downloads/BannerHub/"
+
+    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v0, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object p1
+
+    invoke-virtual {p1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object p1
+
+    const/4 v0, 0x0
+
+    invoke-static {p0, p1, v0}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object p0
+
+    .line 195
+    invoke-virtual {p0}, Landroid/widget/Toast;->show()V
+
+    return-void
+.end method
+
+.method synthetic lambda$backupComponent$6$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/lang/Exception;)V
+    .locals 2
+
+    .line 199
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    const-string v1, "Backup failed: "
+
+    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {p1}, Ljava/lang/Exception;->getMessage()Ljava/lang/String;
+
+    move-result-object p1
+
+    invoke-virtual {v0, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object p1
+
+    invoke-virtual {p1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object p1
+
+    const/4 v0, 0x0
+
+    invoke-static {p0, p1, v0}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object p0
+
+    .line 200
+    invoke-virtual {p0}, Landroid/widget/Toast;->show()V
+
+    return-void
+.end method
+
+.method synthetic lambda$backupComponent$7$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/io/File;Ljava/io/File;Landroid/os/Handler;Ljava/lang/String;)V
+    .locals 0
+
+    .line 192
+    :try_start_0
+    invoke-static {p1, p2}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->copyDir(Ljava/io/File;Ljava/io/File;)V
+
+    .line 193
+    new-instance p1, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;
+
+    invoke-direct {p1, p0, p4}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda2;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/lang/String;)V
+
+    invoke-virtual {p3, p1}, Landroid/os/Handler;->post(Ljava/lang/Runnable;)Z
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    return-void
+
+    :catch_0
+    move-exception p1
+
+    .line 197
+    const-string p2, "BannerHub"
+
+    const-string p4, "Backup failed"
+
+    invoke-static {p2, p4, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 198
+    new-instance p2, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;
+
+    invoke-direct {p2, p0, p1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda3;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/lang/Exception;)V
+
+    invoke-virtual {p3, p2}, Landroid/os/Handler;->post(Ljava/lang/Runnable;)Z
+
+    return-void
+.end method
+
+.method synthetic lambda$onActivityResult$2$app-revanced-extension-gamehub-ComponentManagerActivity()V
+    .locals 2
+
+    .line 151
+    const-string v0, "Injected successfully"
+
+    const/4 v1, 0x0
+
+    invoke-static {p0, v0, v1}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Landroid/widget/Toast;->show()V
+
+    .line 152
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->showComponents()V
+
+    return-void
+.end method
+
+.method synthetic lambda$onActivityResult$3$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/lang/String;)V
+    .locals 2
+
+    .line 158
+    new-instance v0, Ljava/lang/StringBuilder;
+
+    const-string v1, "Inject failed: "
+
+    invoke-direct {v0, v1}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v0, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object p1
+
+    invoke-virtual {p1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object p1
+
+    const/4 v0, 0x1
+
+    invoke-static {p0, p1, v0}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object p0
+
+    invoke-virtual {p0}, Landroid/widget/Toast;->show()V
+
+    return-void
+.end method
+
+.method synthetic lambda$onActivityResult$4$app-revanced-extension-gamehub-ComponentManagerActivity(Landroid/net/Uri;Ljava/io/File;Ljava/lang/String;Landroid/os/Handler;)V
+    .locals 1
+
+    .line 145
+    :try_start_0
+    invoke-virtual {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->getContentResolver()Landroid/content/ContentResolver;
+
+    move-result-object v0
+
+    invoke-static {v0, p1, p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->extract(Landroid/content/ContentResolver;Landroid/net/Uri;Ljava/io/File;)V
+
+    .line 146
+    invoke-direct {p0, p1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->getFileName(Landroid/net/Uri;)Ljava/lang/String;
+
+    move-result-object p1
+
+    if-eqz p1, :cond_0
+
+    .line 148
+    iget-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->injectedPrefs:Landroid/content/SharedPreferences;
+
+    invoke-interface {p2}, Landroid/content/SharedPreferences;->edit()Landroid/content/SharedPreferences$Editor;
+
+    move-result-object p2
+
+    invoke-interface {p2, p3, p1}, Landroid/content/SharedPreferences$Editor;->putString(Ljava/lang/String;Ljava/lang/String;)Landroid/content/SharedPreferences$Editor;
+
+    move-result-object p1
+
+    invoke-interface {p1}, Landroid/content/SharedPreferences$Editor;->apply()V
+
+    .line 150
+    :cond_0
+    new-instance p1, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0;
+
+    invoke-direct {p1, p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda0;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;)V
+
+    invoke-virtual {p4, p1}, Landroid/os/Handler;->post(Ljava/lang/Runnable;)Z
+    :try_end_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_0
+
+    return-void
+
+    :catchall_0
+    move-exception p1
+
+    .line 155
+    const-string p2, "BannerHub"
+
+    const-string p3, "Extraction failed"
+
+    invoke-static {p2, p3, p1}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    .line 156
+    invoke-virtual {p1}, Ljava/lang/Throwable;->getMessage()Ljava/lang/String;
+
+    move-result-object p2
+
+    if-eqz p2, :cond_1
+
+    invoke-virtual {p1}, Ljava/lang/Throwable;->getMessage()Ljava/lang/String;
+
+    move-result-object p1
+
+    goto :goto_0
+
+    :cond_1
+    invoke-virtual {p1}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+
+    move-result-object p1
+
+    invoke-virtual {p1}, Ljava/lang/Class;->getSimpleName()Ljava/lang/String;
+
+    move-result-object p1
+
+    .line 157
+    :goto_0
+    new-instance p2, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;
+
+    invoke-direct {p2, p0, p1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda1;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Ljava/lang/String;)V
+
+    invoke-virtual {p4, p2}, Landroid/os/Handler;->post(Ljava/lang/Runnable;)Z
+
+    return-void
+.end method
+
+.method synthetic lambda$showComponents$0$app-revanced-extension-gamehub-ComponentManagerActivity(Ljava/util/List;Landroid/widget/AdapterView;Landroid/view/View;IJ)V
+    .locals 0
+
+    .line 86
+    invoke-interface {p1, p4}, Ljava/util/List;->get(I)Ljava/lang/Object;
+
+    move-result-object p1
+
+    check-cast p1, Ljava/lang/String;
+
+    .line 87
+    const-string p2, "(no components found)"
+
+    invoke-virtual {p1, p2}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+
+    move-result p2
+
+    if-eqz p2, :cond_0
+
+    return-void
+
+    .line 89
+    :cond_0
+    const-string p2, " [-> "
+
+    invoke-virtual {p1, p2}, Ljava/lang/String;->indexOf(Ljava/lang/String;)I
+
+    move-result p2
+
+    if-ltz p2, :cond_1
+
+    const/4 p3, 0x0
+
+    .line 90
+    invoke-virtual {p1, p3, p2}, Ljava/lang/String;->substring(II)Ljava/lang/String;
+
+    move-result-object p1
+
+    :cond_1
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->selectedComponent:Ljava/lang/String;
+
+    .line 91
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->showOptions()V
+
+    return-void
+.end method
+
+.method synthetic lambda$showOptions$1$app-revanced-extension-gamehub-ComponentManagerActivity(Landroid/widget/AdapterView;Landroid/view/View;IJ)V
+    .locals 0
+
+    .line 0
+    if-eqz p3, :cond_2
+
+    const/4 p1, 0x1
+
+    if-eq p3, p1, :cond_1
+
+    const/4 p1, 0x2
+
+    if-eq p3, p1, :cond_0
+
+    return-void
+
+    .line 118
+    :cond_0
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->showComponents()V
+
+    return-void
+
+    .line 117
+    :cond_1
+    iget-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->selectedComponent:Ljava/lang/String;
+
+    invoke-direct {p0, p1}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->backupComponent(Ljava/lang/String;)V
+
+    return-void
+
+    .line 116
+    :cond_2
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->openFilePicker()V
+
+    return-void
+.end method
+
+.method protected onActivityResult(IILandroid/content/Intent;)V
+    .locals 6
+
+    .line 134
+    invoke-super {p0, p1, p2, p3}, Landroid/app/Activity;->onActivityResult(IILandroid/content/Intent;)V
+
+    const/16 v0, 0x3e9
+
+    if-ne p1, v0, :cond_1
+
+    const/4 p1, -0x1
+
+    if-ne p2, p1, :cond_1
+
+    if-eqz p3, :cond_1
+
+    .line 136
+    invoke-virtual {p3}, Landroid/content/Intent;->getData()Landroid/net/Uri;
+
+    move-result-object p1
+
+    if-nez p1, :cond_0
+
+    goto :goto_0
+
+    .line 138
+    :cond_0
+    invoke-virtual {p3}, Landroid/content/Intent;->getData()Landroid/net/Uri;
+
+    move-result-object v2
+
+    .line 139
+    new-instance v3, Ljava/io/File;
+
+    iget-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->componentsDir:Ljava/io/File;
+
+    iget-object p2, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->selectedComponent:Ljava/lang/String;
+
+    invoke-direct {v3, p1, p2}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    .line 140
+    iget-object v4, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->selectedComponent:Ljava/lang/String;
+
+    .line 142
+    new-instance v5, Landroid/os/Handler;
+
+    invoke-static {}, Landroid/os/Looper;->getMainLooper()Landroid/os/Looper;
+
+    move-result-object p1
+
+    invoke-direct {v5, p1}, Landroid/os/Handler;-><init>(Landroid/os/Looper;)V
+
+    .line 143
+    new-instance p1, Ljava/lang/Thread;
+
+    new-instance v0, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;
+
+    move-object v1, p0
+
+    invoke-direct/range {v0 .. v5}, Lapp/revanced/extension/gamehub/ComponentManagerActivity$$ExternalSyntheticLambda6;-><init>(Lapp/revanced/extension/gamehub/ComponentManagerActivity;Landroid/net/Uri;Ljava/io/File;Ljava/lang/String;Landroid/os/Handler;)V
+
+    invoke-direct {p1, v0}, Ljava/lang/Thread;-><init>(Ljava/lang/Runnable;)V
+
+    .line 160
+    invoke-virtual {p1}, Ljava/lang/Thread;->start()V
+
+    :cond_1
+    :goto_0
+    return-void
+.end method
+
+.method protected onCreate(Landroid/os/Bundle;)V
+    .locals 2
+
+    .line 58
+    invoke-super {p0, p1}, Landroid/app/Activity;->onCreate(Landroid/os/Bundle;)V
+
+    .line 59
+    new-instance p1, Ljava/io/File;
+
+    invoke-virtual {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->getFilesDir()Ljava/io/File;
+
+    move-result-object v0
+
+    const-string v1, "usr/home/components"
+
+    invoke-direct {p1, v0, v1}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->componentsDir:Ljava/io/File;
+
+    .line 60
+    const-string p1, "bh_injected"
+
+    const/4 v0, 0x0
+
+    invoke-virtual {p0, p1, v0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->getSharedPreferences(Ljava/lang/String;I)Landroid/content/SharedPreferences;
+
+    move-result-object p1
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->injectedPrefs:Landroid/content/SharedPreferences;
+
+    .line 61
+    invoke-direct {p0}, Lapp/revanced/extension/gamehub/ComponentManagerActivity;->showComponents()V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0.smali
@@ -1,0 +1,36 @@
+.class public final synthetic Lapp/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0;
+.super Ljava/lang/Object;
+.source "D8$$SyntheticClass"
+
+# interfaces
+.implements Landroid/view/View$OnClickListener;
+
+
+# instance fields
+.field public final synthetic f$0:Landroid/app/Activity;
+
+
+# direct methods
+.method public synthetic constructor <init>(Landroid/app/Activity;)V
+    .locals 0
+
+    .line 0
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    iput-object p1, p0, Lapp/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0;->f$0:Landroid/app/Activity;
+
+    return-void
+.end method
+
+
+# virtual methods
+.method public final onClick(Landroid/view/View;)V
+    .locals 0
+
+    .line 0
+    iget-object p0, p0, Lapp/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0;->f$0:Landroid/app/Activity;
+
+    invoke-static {p0, p1}, Lapp/revanced/extension/gamehub/ComponentManagerHelper;->lambda$setupBciButton$0(Landroid/app/Activity;Landroid/view/View;)V
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerHelper.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/ComponentManagerHelper.smali
@@ -1,0 +1,409 @@
+.class public final Lapp/revanced/extension/gamehub/ComponentManagerHelper;
+.super Ljava/lang/Object;
+.source "ComponentManagerHelper.java"
+
+
+# static fields
+.field private static final COMPONENTS_MENU_ID:I = 0x9
+
+.field private static final TAG:Ljava/lang/String; = "BannerHub"
+
+
+# direct methods
+.method private constructor <init>()V
+    .locals 0
+
+    .line 27
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    return-void
+.end method
+
+.method public static addComponentsMenuItem(Ljava/util/List;)V
+    .locals 9
+
+    .line 39
+    :try_start_0
+    const-string v0, "android.app.ActivityThread"
+
+    .line 40
+    invoke-static {v0}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;
+
+    move-result-object v0
+
+    const-string v1, "currentApplication"
+
+    const/4 v2, 0x0
+
+    new-array v3, v2, [Ljava/lang/Class;
+
+    .line 41
+    invoke-virtual {v0, v1, v3}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object v0
+
+    new-array v1, v2, [Ljava/lang/Object;
+
+    const/4 v3, 0x0
+
+    .line 42
+    invoke-virtual {v0, v3, v1}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v0
+
+    check-cast v0, Landroid/content/Context;
+
+    .line 44
+    const-string v1, "com.xj.landscape.launcher.ui.menu.HomeLeftMenuDialog$MenuItem"
+
+    invoke-static {v1}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;
+
+    move-result-object v1
+
+    .line 46
+    const-string v3, "kotlin.jvm.internal.DefaultConstructorMarker"
+
+    invoke-static {v3}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;
+
+    move-result-object v3
+
+    const/4 v4, 0x6
+
+    .line 51
+    new-array v4, v4, [Ljava/lang/Class;
+
+    sget-object v5, Ljava/lang/Integer;->TYPE:Ljava/lang/Class;
+
+    aput-object v5, v4, v2
+
+    sget-object v2, Ljava/lang/Integer;->TYPE:Ljava/lang/Class;
+
+    const/4 v5, 0x1
+
+    aput-object v2, v4, v5
+
+    const-class v2, Ljava/lang/String;
+
+    const/4 v6, 0x2
+
+    aput-object v2, v4, v6
+
+    const-class v2, Ljava/lang/String;
+
+    const/4 v6, 0x3
+
+    aput-object v2, v4, v6
+
+    sget-object v2, Ljava/lang/Integer;->TYPE:Ljava/lang/Class;
+
+    const/4 v6, 0x4
+
+    aput-object v2, v4, v6
+
+    const/4 v2, 0x5
+
+    aput-object v3, v4, v2
+
+    invoke-virtual {v1, v4}, Ljava/lang/Class;->getDeclaredConstructor([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+
+    move-result-object v1
+
+    .line 54
+    invoke-virtual {v1, v5}, Ljava/lang/reflect/Constructor;->setAccessible(Z)V
+
+    .line 56
+    invoke-virtual {v0}, Landroid/content/Context;->getResources()Landroid/content/res/Resources;
+
+    move-result-object v2
+
+    const-string v3, "menu_setting_normal"
+
+    const-string v4, "drawable"
+
+    .line 57
+    invoke-virtual {v0}, Landroid/content/Context;->getPackageName()Ljava/lang/String;
+
+    move-result-object v0
+
+    .line 56
+    invoke-virtual {v2, v3, v4, v0}, Landroid/content/res/Resources;->getIdentifier(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I
+
+    move-result v0
+
+    const/16 v2, 0x9
+
+    .line 61
+    invoke-static {v2}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v3
+
+    invoke-static {v0}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v4
+
+    const-string v5, "Components"
+
+    const/16 v0, 0x8
+
+    invoke-static {v0}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v7
+
+    const/4 v8, 0x0
+
+    const/4 v6, 0x0
+
+    filled-new-array/range {v3 .. v8}, [Ljava/lang/Object;
+
+    move-result-object v0
+
+    .line 60
+    invoke-virtual {v1, v0}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v0
+
+    .line 64
+    invoke-interface {p0, v0}, Ljava/util/List;->add(Ljava/lang/Object;)Z
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    return-void
+
+    :catch_0
+    move-exception v0
+
+    move-object p0, v0
+
+    .line 66
+    const-string v0, "BannerHub"
+
+    const-string v1, "addComponentsMenuItem failed"
+
+    invoke-static {v0, v1, p0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    return-void
+.end method
+
+.method public static handleMenuItemClick(Ljava/lang/Object;Ljava/lang/Object;Landroid/app/Activity;)Z
+    .locals 4
+
+    const/4 v0, 0x0
+
+    .line 82
+    :try_start_0
+    invoke-virtual {p1}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+
+    move-result-object v1
+
+    const-string v2, "a"
+
+    new-array v3, v0, [Ljava/lang/Class;
+
+    invoke-virtual {v1, v2, v3}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object v1
+
+    new-array v2, v0, [Ljava/lang/Object;
+
+    invoke-virtual {v1, p1, v2}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object p1
+
+    check-cast p1, Ljava/lang/Integer;
+
+    invoke-virtual {p1}, Ljava/lang/Integer;->intValue()I
+
+    move-result p1
+
+    const/16 v1, 0x9
+
+    if-eq p1, v1, :cond_0
+
+    return v0
+
+    .line 86
+    :cond_0
+    invoke-virtual {p0}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+
+    move-result-object p1
+
+    const-string v1, "dismiss"
+
+    new-array v2, v0, [Ljava/lang/Class;
+
+    invoke-virtual {p1, v1, v2}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object p1
+
+    new-array v1, v0, [Ljava/lang/Object;
+
+    invoke-virtual {p1, p0, v1}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    .line 88
+    new-instance p0, Landroid/content/Intent;
+
+    const-class p1, Lapp/revanced/extension/gamehub/ComponentManagerActivity;
+
+    invoke-direct {p0, p2, p1}, Landroid/content/Intent;-><init>(Landroid/content/Context;Ljava/lang/Class;)V
+
+    const/high16 p1, 0x10000000
+
+    .line 89
+    invoke-virtual {p0, p1}, Landroid/content/Intent;->addFlags(I)Landroid/content/Intent;
+
+    .line 90
+    invoke-virtual {p2, p0}, Landroid/app/Activity;->startActivity(Landroid/content/Intent;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    const/4 p0, 0x1
+
+    return p0
+
+    :catch_0
+    move-exception p0
+
+    .line 93
+    const-string p1, "BannerHub"
+
+    const-string p2, "handleMenuItemClick failed"
+
+    invoke-static {p1, p2, p0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    return v0
+.end method
+
+.method static synthetic lambda$setupBciButton$0(Landroid/app/Activity;Landroid/view/View;)V
+    .locals 3
+
+    const/4 p1, 0x0
+
+    .line 117
+    :try_start_0
+    invoke-virtual {p0}, Landroid/app/Activity;->getPackageManager()Landroid/content/pm/PackageManager;
+
+    move-result-object v0
+
+    .line 118
+    const-string v1, "com.banner.inject"
+
+    invoke-virtual {v0, v1}, Landroid/content/pm/PackageManager;->getLaunchIntentForPackage(Ljava/lang/String;)Landroid/content/Intent;
+
+    move-result-object v0
+
+    if-eqz v0, :cond_0
+
+    .line 120
+    invoke-virtual {p0, v0}, Landroid/app/Activity;->startActivity(Landroid/content/Intent;)V
+
+    return-void
+
+    .line 122
+    :cond_0
+    const-string v0, "BannersComponentInjector not installed"
+
+    invoke-static {p0, v0, p1}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object v0
+
+    .line 124
+    invoke-virtual {v0}, Landroid/widget/Toast;->show()V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    return-void
+
+    :catch_0
+    move-exception v0
+
+    .line 127
+    new-instance v1, Ljava/lang/StringBuilder;
+
+    const-string v2, "Error: "
+
+    invoke-direct {v1, v2}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v0}, Ljava/lang/Exception;->getMessage()Ljava/lang/String;
+
+    move-result-object v0
+
+    invoke-virtual {v1, v0}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v0
+
+    invoke-virtual {v0}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v0
+
+    invoke-static {p0, v0, p1}, Landroid/widget/Toast;->makeText(Landroid/content/Context;Ljava/lang/CharSequence;I)Landroid/widget/Toast;
+
+    move-result-object p0
+
+    .line 128
+    invoke-virtual {p0}, Landroid/widget/Toast;->show()V
+
+    return-void
+.end method
+
+.method public static setupBciButton(Landroid/app/Activity;)V
+    .locals 4
+
+    .line 108
+    :try_start_0
+    invoke-virtual {p0}, Landroid/app/Activity;->getResources()Landroid/content/res/Resources;
+
+    move-result-object v0
+
+    const-string v1, "iv_bci_launcher"
+
+    const-string v2, "id"
+
+    .line 109
+    invoke-virtual {p0}, Landroid/app/Activity;->getPackageName()Ljava/lang/String;
+
+    move-result-object v3
+
+    .line 108
+    invoke-virtual {v0, v1, v2, v3}, Landroid/content/res/Resources;->getIdentifier(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)I
+
+    move-result v0
+
+    if-nez v0, :cond_0
+
+    goto :goto_0
+
+    .line 112
+    :cond_0
+    invoke-virtual {p0, v0}, Landroid/app/Activity;->findViewById(I)Landroid/view/View;
+
+    move-result-object v0
+
+    if-nez v0, :cond_1
+
+    :goto_0
+    return-void
+
+    .line 115
+    :cond_1
+    new-instance v1, Lapp/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0;
+
+    invoke-direct {v1, p0}, Lapp/revanced/extension/gamehub/ComponentManagerHelper$$ExternalSyntheticLambda0;-><init>(Landroid/app/Activity;)V
+
+    invoke-virtual {v0, v1}, Landroid/view/View;->setOnClickListener(Landroid/view/View$OnClickListener;)V
+    :try_end_0
+    .catch Ljava/lang/Exception; {:try_start_0 .. :try_end_0} :catch_0
+
+    return-void
+
+    :catch_0
+    move-exception p0
+
+    .line 132
+    const-string v0, "BannerHub"
+
+    const-string v1, "setupBciButton failed"
+
+    invoke-static {v0, v1, p0}, Landroid/util/Log;->e(Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+
+    return-void
+.end method

--- a/patches/new_files/smali_classes11/app/revanced/extension/gamehub/WcpExtractor.smali
+++ b/patches/new_files/smali_classes11/app/revanced/extension/gamehub/WcpExtractor.smali
@@ -1,0 +1,949 @@
+.class public final Lapp/revanced/extension/gamehub/WcpExtractor;
+.super Ljava/lang/Object;
+.source "WcpExtractor.java"
+
+
+# static fields
+.field private static final BUF:I = 0x2000
+
+.field private static final TAG:Ljava/lang/String; = "BannerHub"
+
+
+# direct methods
+.method private constructor <init>()V
+    .locals 0
+
+    .line 40
+    invoke-direct {p0}, Ljava/lang/Object;-><init>()V
+
+    return-void
+.end method
+
+.method static clearDir(Ljava/io/File;)V
+    .locals 5
+
+    .line 225
+    invoke-virtual {p0}, Ljava/io/File;->listFiles()[Ljava/io/File;
+
+    move-result-object p0
+
+    if-nez p0, :cond_0
+
+    goto :goto_1
+
+    .line 227
+    :cond_0
+    array-length v0, p0
+
+    const/4 v1, 0x0
+
+    :goto_0
+    if-ge v1, v0, :cond_3
+
+    aget-object v2, p0, v1
+
+    .line 228
+    invoke-virtual {v2}, Ljava/io/File;->isDirectory()Z
+
+    move-result v3
+
+    if-eqz v3, :cond_1
+
+    .line 229
+    invoke-static {v2}, Lapp/revanced/extension/gamehub/WcpExtractor;->clearDir(Ljava/io/File;)V
+
+    .line 231
+    :cond_1
+    invoke-virtual {v2}, Ljava/io/File;->delete()Z
+
+    move-result v3
+
+    if-nez v3, :cond_2
+
+    .line 232
+    new-instance v3, Ljava/lang/StringBuilder;
+
+    const-string v4, "clearDir: failed to delete "
+
+    invoke-direct {v3, v4}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v2}, Ljava/io/File;->getAbsolutePath()Ljava/lang/String;
+
+    move-result-object v2
+
+    invoke-virtual {v3, v2}, Ljava/lang/StringBuilder;->append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+
+    move-result-object v2
+
+    invoke-virtual {v2}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object v2
+
+    const-string v3, "BannerHub"
+
+    invoke-static {v3, v2}, Landroid/util/Log;->w(Ljava/lang/String;Ljava/lang/String;)I
+
+    :cond_2
+    add-int/lit8 v1, v1, 0x1
+
+    goto :goto_0
+
+    :cond_3
+    :goto_1
+    return-void
+.end method
+
+.method public static extract(Landroid/content/ContentResolver;Landroid/net/Uri;Ljava/io/File;)V
+    .locals 6
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 49
+    invoke-virtual {p0, p1}, Landroid/content/ContentResolver;->openInputStream(Landroid/net/Uri;)Ljava/io/InputStream;
+
+    move-result-object p0
+
+    if-eqz p0, :cond_4
+
+    .line 53
+    :try_start_0
+    new-instance p1, Ljava/io/BufferedInputStream;
+
+    invoke-direct {p1, p0}, Ljava/io/BufferedInputStream;-><init>(Ljava/io/InputStream;)V
+    :try_end_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_3
+
+    const/4 v0, 0x4
+
+    .line 56
+    :try_start_1
+    invoke-virtual {p1, v0}, Ljava/io/BufferedInputStream;->mark(I)V
+
+    .line 57
+    new-array v1, v0, [B
+
+    const/4 v2, 0x0
+
+    .line 58
+    invoke-virtual {p1, v1, v2, v0}, Ljava/io/BufferedInputStream;->read([BII)I
+
+    move-result v0
+
+    .line 59
+    invoke-virtual {p1}, Ljava/io/BufferedInputStream;->reset()V
+
+    const/4 v3, 0x2
+
+    if-lt v0, v3, :cond_3
+
+    .line 62
+    aget-byte v0, v1, v2
+
+    and-int/lit16 v0, v0, 0xff
+
+    const/4 v2, 0x1
+
+    aget-byte v2, v1, v2
+
+    and-int/lit16 v2, v2, 0xff
+
+    .line 63
+    aget-byte v3, v1, v3
+
+    and-int/lit16 v3, v3, 0xff
+
+    const/4 v4, 0x3
+
+    aget-byte v1, v1, v4
+
+    and-int/lit16 v1, v1, 0xff
+
+    const/16 v4, 0x50
+
+    if-ne v0, v4, :cond_0
+
+    const/16 v4, 0x4b
+
+    if-ne v2, v4, :cond_0
+
+    .line 67
+    invoke-static {p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->clearDir(Ljava/io/File;)V
+
+    invoke-virtual {p2}, Ljava/io/File;->mkdirs()Z
+
+    .line 68
+    invoke-static {p1, p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->extractZip(Ljava/io/InputStream;Ljava/io/File;)V
+
+    goto :goto_0
+
+    :cond_0
+    const/16 v4, 0x28
+
+    const/16 v5, 0xfd
+
+    if-ne v0, v4, :cond_1
+
+    const/16 v4, 0xb5
+
+    if-ne v2, v4, :cond_1
+
+    const/16 v4, 0x2f
+
+    if-ne v3, v4, :cond_1
+
+    if-ne v1, v5, :cond_1
+
+    .line 72
+    invoke-static {p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->clearDir(Ljava/io/File;)V
+
+    invoke-virtual {p2}, Ljava/io/File;->mkdirs()Z
+
+    .line 73
+    invoke-static {p1}, Lapp/revanced/extension/gamehub/WcpExtractor;->openZstd(Ljava/io/InputStream;)Ljava/io/InputStream;
+
+    move-result-object v0
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_2
+
+    .line 75
+    :try_start_2
+    invoke-static {v0, p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->extractTar(Ljava/io/InputStream;Ljava/io/File;)V
+    :try_end_2
+    .catchall {:try_start_2 .. :try_end_2} :catchall_0
+
+    .line 77
+    :try_start_3
+    invoke-virtual {v0}, Ljava/io/InputStream;->close()V
+
+    goto :goto_0
+
+    :catchall_0
+    move-exception p2
+
+    invoke-virtual {v0}, Ljava/io/InputStream;->close()V
+
+    .line 78
+    throw p2
+
+    :cond_1
+    if-ne v0, v5, :cond_2
+
+    const/16 v4, 0x37
+
+    if-ne v2, v4, :cond_2
+
+    const/16 v4, 0x7a
+
+    if-ne v3, v4, :cond_2
+
+    const/16 v4, 0x58
+
+    if-ne v1, v4, :cond_2
+
+    .line 82
+    invoke-static {p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->clearDir(Ljava/io/File;)V
+
+    invoke-virtual {p2}, Ljava/io/File;->mkdirs()Z
+
+    .line 83
+    invoke-static {p1}, Lapp/revanced/extension/gamehub/WcpExtractor;->openXz(Ljava/io/InputStream;)Ljava/io/InputStream;
+
+    move-result-object v0
+    :try_end_3
+    .catchall {:try_start_3 .. :try_end_3} :catchall_2
+
+    .line 85
+    :try_start_4
+    invoke-static {v0, p2}, Lapp/revanced/extension/gamehub/WcpExtractor;->extractTar(Ljava/io/InputStream;Ljava/io/File;)V
+    :try_end_4
+    .catchall {:try_start_4 .. :try_end_4} :catchall_1
+
+    .line 87
+    :try_start_5
+    invoke-virtual {v0}, Ljava/io/InputStream;->close()V
+    :try_end_5
+    .catchall {:try_start_5 .. :try_end_5} :catchall_2
+
+    .line 95
+    :goto_0
+    :try_start_6
+    invoke-virtual {p1}, Ljava/io/BufferedInputStream;->close()V
+    :try_end_6
+    .catchall {:try_start_6 .. :try_end_6} :catchall_3
+
+    .line 98
+    invoke-virtual {p0}, Ljava/io/InputStream;->close()V
+
+    return-void
+
+    :catchall_1
+    move-exception p2
+
+    .line 87
+    :try_start_7
+    invoke-virtual {v0}, Ljava/io/InputStream;->close()V
+
+    .line 88
+    throw p2
+
+    .line 91
+    :cond_2
+    new-instance p2, Ljava/lang/Exception;
+
+    const-string v4, "Unknown format (magic: %02X %02X %02X %02X)"
+
+    .line 92
+    invoke-static {v0}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v0
+
+    invoke-static {v2}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v2
+
+    invoke-static {v3}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v3
+
+    invoke-static {v1}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v1
+
+    filled-new-array {v0, v2, v3, v1}, [Ljava/lang/Object;
+
+    move-result-object v0
+
+    .line 91
+    invoke-static {v4, v0}, Ljava/lang/String;->format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+
+    move-result-object v0
+
+    invoke-direct {p2, v0}, Ljava/lang/Exception;-><init>(Ljava/lang/String;)V
+
+    throw p2
+
+    .line 60
+    :cond_3
+    new-instance p2, Ljava/io/IOException;
+
+    const-string v0, "File too short"
+
+    invoke-direct {p2, v0}, Ljava/io/IOException;-><init>(Ljava/lang/String;)V
+
+    throw p2
+    :try_end_7
+    .catchall {:try_start_7 .. :try_end_7} :catchall_2
+
+    :catchall_2
+    move-exception p2
+
+    .line 95
+    :try_start_8
+    invoke-virtual {p1}, Ljava/io/BufferedInputStream;->close()V
+
+    .line 96
+    throw p2
+    :try_end_8
+    .catchall {:try_start_8 .. :try_end_8} :catchall_3
+
+    :catchall_3
+    move-exception p1
+
+    .line 98
+    invoke-virtual {p0}, Ljava/io/InputStream;->close()V
+
+    .line 99
+    throw p1
+
+    .line 50
+    :cond_4
+    new-instance p0, Ljava/io/IOException;
+
+    new-instance p2, Ljava/lang/StringBuilder;
+
+    const-string v0, "Cannot open URI: "
+
+    invoke-direct {p2, v0}, Ljava/lang/StringBuilder;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {p2, p1}, Ljava/lang/StringBuilder;->append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
+
+    move-result-object p1
+
+    invoke-virtual {p1}, Ljava/lang/StringBuilder;->toString()Ljava/lang/String;
+
+    move-result-object p1
+
+    invoke-direct {p0, p1}, Ljava/io/IOException;-><init>(Ljava/lang/String;)V
+
+    throw p0
+.end method
+
+.method private static extractTar(Ljava/io/InputStream;Ljava/io/File;)V
+    .locals 10
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 148
+    const-string v0, "org.apache.commons.compress.archivers.tar.TarArchiveInputStream"
+
+    invoke-static {v0}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;
+
+    move-result-object v0
+
+    const/4 v1, 0x1
+
+    .line 150
+    new-array v2, v1, [Ljava/lang/Class;
+
+    const-class v3, Ljava/io/InputStream;
+
+    const/4 v4, 0x0
+
+    aput-object v3, v2, v4
+
+    invoke-virtual {v0, v2}, Ljava/lang/Class;->getConstructor([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+
+    move-result-object v2
+
+    .line 151
+    filled-new-array {p0}, [Ljava/lang/Object;
+
+    move-result-object p0
+
+    invoke-virtual {v2, p0}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object p0
+
+    .line 153
+    const-string v2, "f"
+
+    new-array v3, v4, [Ljava/lang/Class;
+
+    invoke-virtual {v0, v2, v3}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object v2
+
+    const/16 v3, 0x2000
+
+    .line 156
+    new-array v3, v3, [B
+
+    const/4 v5, 0x0
+
+    move v6, v4
+
+    .line 161
+    :cond_0
+    :goto_0
+    new-array v7, v4, [Ljava/lang/Object;
+
+    invoke-virtual {v2, p0, v7}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v7
+
+    if-eqz v7, :cond_9
+
+    if-nez v5, :cond_1
+
+    .line 163
+    invoke-virtual {v7}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+
+    move-result-object v5
+
+    const-string v8, "p"
+
+    new-array v9, v4, [Ljava/lang/Class;
+
+    invoke-virtual {v5, v8, v9}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object v5
+
+    .line 165
+    :cond_1
+    new-array v8, v4, [Ljava/lang/Object;
+
+    invoke-virtual {v5, v7, v8}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v7
+
+    check-cast v7, Ljava/lang/String;
+
+    if-nez v7, :cond_2
+
+    goto :goto_0
+
+    .line 168
+    :cond_2
+    const-string v8, "/"
+
+    invoke-virtual {v7, v8}, Ljava/lang/String;->endsWith(Ljava/lang/String;)Z
+
+    move-result v8
+
+    if-eqz v8, :cond_3
+
+    goto :goto_0
+
+    .line 170
+    :cond_3
+    const-string v8, "profile.json"
+
+    invoke-virtual {v7, v8}, Ljava/lang/String;->endsWith(Ljava/lang/String;)Z
+
+    move-result v8
+
+    if-eqz v8, :cond_4
+
+    .line 171
+    new-instance v7, Ljava/io/ByteArrayOutputStream;
+
+    invoke-direct {v7}, Ljava/io/ByteArrayOutputStream;-><init>()V
+
+    .line 172
+    invoke-static {p0, v7, v3}, Lapp/revanced/extension/gamehub/WcpExtractor;->pipeReflected(Ljava/lang/Object;Ljava/io/OutputStream;[B)V
+
+    .line 173
+    const-string v8, "UTF-8"
+
+    invoke-virtual {v7, v8}, Ljava/io/ByteArrayOutputStream;->toString(Ljava/lang/String;)Ljava/lang/String;
+
+    move-result-object v7
+
+    .line 174
+    const-string v8, "FEXCore"
+
+    invoke-virtual {v7, v8}, Ljava/lang/String;->contains(Ljava/lang/CharSequence;)Z
+
+    move-result v7
+
+    if-eqz v7, :cond_0
+
+    move v6, v1
+
+    goto :goto_0
+
+    .line 181
+    :cond_4
+    const-string v8, "./"
+
+    invoke-virtual {v7, v8}, Ljava/lang/String;->startsWith(Ljava/lang/String;)Z
+
+    move-result v8
+
+    if-eqz v8, :cond_5
+
+    const/4 v8, 0x2
+
+    invoke-virtual {v7, v8}, Ljava/lang/String;->substring(I)Ljava/lang/String;
+
+    move-result-object v7
+
+    .line 182
+    :cond_5
+    invoke-virtual {v7}, Ljava/lang/String;->isEmpty()Z
+
+    move-result v8
+
+    if-eqz v8, :cond_6
+
+    goto :goto_0
+
+    :cond_6
+    if-eqz v6, :cond_7
+
+    .line 186
+    new-instance v8, Ljava/io/File;
+
+    new-instance v9, Ljava/io/File;
+
+    invoke-direct {v9, v7}, Ljava/io/File;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v9}, Ljava/io/File;->getName()Ljava/lang/String;
+
+    move-result-object v7
+
+    invoke-direct {v8, p1, v7}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    goto :goto_1
+
+    .line 188
+    :cond_7
+    new-instance v8, Ljava/io/File;
+
+    invoke-direct {v8, p1, v7}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    .line 189
+    invoke-virtual {v8}, Ljava/io/File;->getParentFile()Ljava/io/File;
+
+    move-result-object v7
+
+    if-eqz v7, :cond_8
+
+    .line 190
+    invoke-virtual {v7}, Ljava/io/File;->mkdirs()Z
+
+    .line 193
+    :cond_8
+    :goto_1
+    new-instance v7, Ljava/io/FileOutputStream;
+
+    invoke-direct {v7, v8}, Ljava/io/FileOutputStream;-><init>(Ljava/io/File;)V
+
+    .line 194
+    :try_start_0
+    invoke-static {p0, v7, v3}, Lapp/revanced/extension/gamehub/WcpExtractor;->pipeReflected(Ljava/lang/Object;Ljava/io/OutputStream;[B)V
+    :try_end_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_0
+
+    .line 195
+    invoke-virtual {v7}, Ljava/io/FileOutputStream;->close()V
+
+    goto/16 :goto_0
+
+    :catchall_0
+    move-exception p0
+
+    .line 193
+    :try_start_1
+    invoke-virtual {v7}, Ljava/io/FileOutputStream;->close()V
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_1
+
+    goto :goto_2
+
+    :catchall_1
+    move-exception p1
+
+    invoke-virtual {p0, p1}, Ljava/lang/Throwable;->addSuppressed(Ljava/lang/Throwable;)V
+
+    :goto_2
+    throw p0
+
+    .line 199
+    :cond_9
+    const-string p1, "close"
+
+    new-array v1, v4, [Ljava/lang/Class;
+
+    invoke-virtual {v0, p1, v1}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object p1
+
+    new-array v0, v4, [Ljava/lang/Object;
+
+    invoke-virtual {p1, p0, v0}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    return-void
+.end method
+
+.method private static extractZip(Ljava/io/InputStream;Ljava/io/File;)V
+    .locals 3
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/io/IOException;
+        }
+    .end annotation
+
+    const/16 v0, 0x2000
+
+    .line 119
+    new-array v0, v0, [B
+
+    .line 120
+    new-instance v1, Ljava/util/zip/ZipInputStream;
+
+    invoke-direct {v1, p0}, Ljava/util/zip/ZipInputStream;-><init>(Ljava/io/InputStream;)V
+
+    .line 122
+    :goto_0
+    invoke-virtual {v1}, Ljava/util/zip/ZipInputStream;->getNextEntry()Ljava/util/zip/ZipEntry;
+
+    move-result-object p0
+
+    if-eqz p0, :cond_1
+
+    .line 123
+    invoke-virtual {p0}, Ljava/util/zip/ZipEntry;->isDirectory()Z
+
+    move-result v2
+
+    if-eqz v2, :cond_0
+
+    .line 124
+    invoke-virtual {v1}, Ljava/util/zip/ZipInputStream;->closeEntry()V
+
+    goto :goto_0
+
+    .line 128
+    :cond_0
+    new-instance v2, Ljava/io/File;
+
+    invoke-virtual {p0}, Ljava/util/zip/ZipEntry;->getName()Ljava/lang/String;
+
+    move-result-object p0
+
+    invoke-direct {v2, p0}, Ljava/io/File;-><init>(Ljava/lang/String;)V
+
+    invoke-virtual {v2}, Ljava/io/File;->getName()Ljava/lang/String;
+
+    move-result-object p0
+
+    .line 129
+    new-instance v2, Ljava/io/File;
+
+    invoke-direct {v2, p1, p0}, Ljava/io/File;-><init>(Ljava/io/File;Ljava/lang/String;)V
+
+    .line 130
+    new-instance p0, Ljava/io/FileOutputStream;
+
+    invoke-direct {p0, v2}, Ljava/io/FileOutputStream;-><init>(Ljava/io/File;)V
+
+    .line 131
+    :try_start_0
+    invoke-static {v1, p0, v0}, Lapp/revanced/extension/gamehub/WcpExtractor;->pipe(Ljava/io/InputStream;Ljava/io/OutputStream;[B)V
+    :try_end_0
+    .catchall {:try_start_0 .. :try_end_0} :catchall_0
+
+    .line 132
+    invoke-virtual {p0}, Ljava/io/FileOutputStream;->close()V
+
+    .line 133
+    invoke-virtual {v1}, Ljava/util/zip/ZipInputStream;->closeEntry()V
+
+    goto :goto_0
+
+    :catchall_0
+    move-exception p1
+
+    .line 130
+    :try_start_1
+    invoke-virtual {p0}, Ljava/io/FileOutputStream;->close()V
+    :try_end_1
+    .catchall {:try_start_1 .. :try_end_1} :catchall_1
+
+    goto :goto_1
+
+    :catchall_1
+    move-exception p0
+
+    invoke-virtual {p1, p0}, Ljava/lang/Throwable;->addSuppressed(Ljava/lang/Throwable;)V
+
+    :goto_1
+    throw p1
+
+    .line 135
+    :cond_1
+    invoke-virtual {v1}, Ljava/util/zip/ZipInputStream;->close()V
+
+    return-void
+.end method
+
+.method private static openXz(Ljava/io/InputStream;)Ljava/io/InputStream;
+    .locals 4
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 111
+    const-string v0, "org.tukaani.xz.XZInputStream"
+
+    invoke-static {v0}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;
+
+    move-result-object v0
+
+    const/4 v1, 0x2
+
+    .line 112
+    new-array v1, v1, [Ljava/lang/Class;
+
+    const/4 v2, 0x0
+
+    const-class v3, Ljava/io/InputStream;
+
+    aput-object v3, v1, v2
+
+    const/4 v2, 0x1
+
+    sget-object v3, Ljava/lang/Integer;->TYPE:Ljava/lang/Class;
+
+    aput-object v3, v1, v2
+
+    invoke-virtual {v0, v1}, Ljava/lang/Class;->getConstructor([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+
+    move-result-object v0
+
+    const/4 v1, -0x1
+
+    .line 113
+    invoke-static {v1}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v1
+
+    filled-new-array {p0, v1}, [Ljava/lang/Object;
+
+    move-result-object p0
+
+    invoke-virtual {v0, p0}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object p0
+
+    check-cast p0, Ljava/io/InputStream;
+
+    return-object p0
+.end method
+
+.method private static openZstd(Ljava/io/InputStream;)Ljava/io/InputStream;
+    .locals 4
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 105
+    const-string v0, "com.github.luben.zstd.ZstdInputStreamNoFinalizer"
+
+    invoke-static {v0}, Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;
+
+    move-result-object v0
+
+    const/4 v1, 0x1
+
+    .line 106
+    new-array v1, v1, [Ljava/lang/Class;
+
+    const/4 v2, 0x0
+
+    const-class v3, Ljava/io/InputStream;
+
+    aput-object v3, v1, v2
+
+    invoke-virtual {v0, v1}, Ljava/lang/Class;->getConstructor([Ljava/lang/Class;)Ljava/lang/reflect/Constructor;
+
+    move-result-object v0
+
+    .line 107
+    filled-new-array {p0}, [Ljava/lang/Object;
+
+    move-result-object p0
+
+    invoke-virtual {v0, p0}, Ljava/lang/reflect/Constructor;->newInstance([Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object p0
+
+    check-cast p0, Ljava/io/InputStream;
+
+    return-object p0
+.end method
+
+.method private static pipe(Ljava/io/InputStream;Ljava/io/OutputStream;[B)V
+    .locals 2
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/io/IOException;
+        }
+    .end annotation
+
+    .line 206
+    :goto_0
+    invoke-virtual {p0, p2}, Ljava/io/InputStream;->read([B)I
+
+    move-result v0
+
+    if-lez v0, :cond_0
+
+    const/4 v1, 0x0
+
+    invoke-virtual {p1, p2, v1, v0}, Ljava/io/OutputStream;->write([BII)V
+
+    goto :goto_0
+
+    :cond_0
+    return-void
+.end method
+
+.method private static pipeReflected(Ljava/lang/Object;Ljava/io/OutputStream;[B)V
+    .locals 5
+    .annotation system Ldalvik/annotation/Throws;
+        value = {
+            Ljava/lang/Exception;
+        }
+    .end annotation
+
+    .line 214
+    invoke-virtual {p0}, Ljava/lang/Object;->getClass()Ljava/lang/Class;
+
+    move-result-object v0
+
+    const/4 v1, 0x3
+
+    new-array v1, v1, [Ljava/lang/Class;
+
+    const-class v2, [B
+
+    const/4 v3, 0x0
+
+    aput-object v2, v1, v3
+
+    const/4 v2, 0x1
+
+    sget-object v4, Ljava/lang/Integer;->TYPE:Ljava/lang/Class;
+
+    aput-object v4, v1, v2
+
+    const/4 v2, 0x2
+
+    sget-object v4, Ljava/lang/Integer;->TYPE:Ljava/lang/Class;
+
+    aput-object v4, v1, v2
+
+    const-string v2, "read"
+
+    invoke-virtual {v0, v2, v1}, Ljava/lang/Class;->getMethod(Ljava/lang/String;[Ljava/lang/Class;)Ljava/lang/reflect/Method;
+
+    move-result-object v0
+
+    .line 216
+    :goto_0
+    invoke-static {v3}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v1
+
+    array-length v2, p2
+
+    invoke-static {v2}, Ljava/lang/Integer;->valueOf(I)Ljava/lang/Integer;
+
+    move-result-object v2
+
+    filled-new-array {p2, v1, v2}, [Ljava/lang/Object;
+
+    move-result-object v1
+
+    invoke-virtual {v0, p0, v1}, Ljava/lang/reflect/Method;->invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+
+    move-result-object v1
+
+    check-cast v1, Ljava/lang/Integer;
+
+    invoke-virtual {v1}, Ljava/lang/Integer;->intValue()I
+
+    move-result v1
+
+    if-lez v1, :cond_0
+
+    .line 217
+    invoke-virtual {p1, p2, v3, v1}, Ljava/io/OutputStream;->write([BII)V
+
+    goto :goto_0
+
+    :cond_0
+    return-void
+.end method


### PR DESCRIPTION
## Summary

- **Component Manager** — adds a "Components" sidebar menu item (id=9) that launches a built-in two-level ListView activity for injecting/backing up WCP Windows component archives directly from the device
- **BCI Launcher Button** — adds `iv_bci_launcher` icon button to the main toolbar (after the search icon) that opens [BannersComponentInjector](https://github.com/The412Banner/BannersComponentInjector) if installed, or shows a toast if not

## How It Works

### Extension classes (`patches/new_files/smali_classes11/`)
Pre-compiled smali from three Java source files (also provided in `extension/` for reference):
- `ComponentManagerActivity` — two-level ListView: component list → Inject / Backup / Back buttons
- `ComponentManagerHelper` — static helpers called from injected smali; uses full reflection so there is no compile-time dependency on GameHub bytecode
- `WcpExtractor` — magic-byte detection (ZIP / zstd-tar / XZ-tar); extracts WCP archives using GameHub's own bundled commons-compress, zstd-jni, and tukaani xz (no extra dependencies introduced)

Classes are placed in `smali_classes11/` to avoid dex-index conflicts with `classes.dex`–`classes10.dex`.

### Smali injection points (all in `smali_classes5/`)

| File | Injection |
|------|-----------|
| `HomeLeftMenuDialog.smali` | Appends `addComponentsMenuItem(list)` just before `return-void` at end of the menu-builder method |
| `HomeLeftMenuDialog$init$1$9$2.smali` | Intercepts `a(MenuItem)` at entry; routes id=9 to `handleMenuItemClick()`; all other ids fall through to the original packed-switch |
| `LandscapeLauncherMainActivity.smali` | Calls `setupBciButton(activity)` after `X2()V` in `initView()` |

### Resource patches
- `ids.xml` — adds `iv_bci_launcher` id
- `public.xml` — registers `iv_bci_launcher` at `0x7f0a0e80`
- `llauncher_activity_new_launcher_main.xml` — inserts `FocusableImageView iv_bci_launcher` after `iv_search` in the toolbar
- `AndroidManifest.xml` — registers `ComponentManagerActivity`

## Notes on 5.1.0 compatibility

The smali patches were developed and verified against a 5.1.4 decompile. The injection line offsets for 5.1.0 are estimated from the existing patch context — the `patch` command's context matching should handle small differences. If any hunk fails, regenerating with `generate-patches.sh` against the 5.1.0 decompile will produce exact offsets.

The click-handler class `HomeLeftMenuDialog$init$1$9$2` may have a different lambda suffix in 5.1.0 (Kotlin anonymous class numbering depends on source-code lambda count). After running `./patch.sh`, check `work/decompiled/smali_classes5/com/xj/landscape/launcher/ui/menu/` for the correct `$init$1$N$2.smali` filename and update the patch file name accordingly.

## Test plan

- [ ] Run `./patch.sh` with the 5.1.0 APK — all patches apply without warnings
- [ ] Install the output APK — sidebar shows "Components" item
- [ ] Tap "Components" — `ComponentManagerActivity` launches
- [ ] Inject a WCP component — extraction succeeds for DXVK (zstd-tar), FEXCore (XZ-tar), and plain ZIP drivers
- [ ] Backup a component — file saved to `Downloads/`
- [ ] BCI button visible in toolbar — tapping opens BannersComponentInjector (or shows toast if not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Component Manager: Manage game hub extensions with file injection and backup capabilities
  * BCI quick-launch button for accessing installed components
  * Battery percentage status display on launcher

* **UI Enhancements**
  * Refreshed launcher interface with new dashboard elements
  * Improved menu navigation with streamlined component options
  * Enhanced status indicators for better visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->