### PR TITLE
fix: update apktool to 2.12.1 and fix generate-patches.sh arithmetic

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -19,7 +19,7 @@ on:
 env:
   SOURCE_APK_URL: https://github.com/Producdevity/gamehub-lite/releases/download/v5.1.0-patch/GameHub-5.1.0.apk
   SOURCE_APK_MD5: 42db81116bf3c74e52e6f6afb4ec9f91
-  APKTOOL_VERSION: "2.10.0"
+  APKTOOL_VERSION: "2.12.1"
 
 jobs:
   build:

--- a/generate-patches.sh
+++ b/generate-patches.sh
@@ -8,11 +8,11 @@
 set -e
 
 # Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+RED='[0;31m'
+GREEN='[0;32m'
+YELLOW='[1;33m'
+BLUE='[0;34m'
+NC='[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DECOMPILED_DIR="$SCRIPT_DIR/decompiled"
@@ -161,7 +161,7 @@ generate_patches() {
             dir=$(dirname "$PATCHES_DIR/binary_replacements/$file")
             mkdir -p "$dir"
             cp "$DECOMPILED_DIR/lite/$file" "$PATCHES_DIR/binary_replacements/$file"
-            ((binary_count++))
+            binary_count=$((binary_count+1))
         else
             # Generate unified diff for text files with portable paths
             dir=$(dirname "$PATCHES_DIR/diffs/$file")
@@ -171,7 +171,7 @@ generate_patches() {
                 --label "b/$file" \
                 "$DECOMPILED_DIR/original/$file" "$DECOMPILED_DIR/lite/$file" \
                 > "$PATCHES_DIR/diffs/$file.patch" 2>/dev/null || true
-            ((text_count++))
+            text_count=$((text_count+1))
         fi
     done < "$PATCHES_DIR/files_to_patch.txt"
 
@@ -189,7 +189,7 @@ copy_new_files() {
         mkdir -p "$dir"
         if [ -f "$DECOMPILED_DIR/lite/$file" ]; then
             cp "$DECOMPILED_DIR/lite/$file" "$PATCHES_DIR/new_files/$file"
-            ((count++))
+            count=$((count+1))
         fi
     done < "$PATCHES_DIR/files_to_add.txt"
 


### PR DESCRIPTION
## Summary

Two CI build fixes:

- **Update `APKTOOL_VERSION` from `2.10.0` to `2.12.1`** — the version mismatch caused 7 patch files to fail (including `AndroidManifest.xml`, layout files, and `WineActivity.smali`), cascading into an aapt2 link failure on CI.
- **Fix `((count++))` arithmetic in `generate-patches.sh`** — `((count++))` exits with code 1 when the counter is 0, which kills the script under `set -e` before any patches are reported. Replaced with `count=$((count+1))`.

## Test plan
- [ ] Build passes end-to-end with no patch failures
- [ ] `generate-patches.sh` completes without early exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated apktool version to 2.12.1 in the build workflow for enhanced build operations.
  * Updated build script formatting and syntax for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->