### PR TITLE
fix: allow launch when getUnknownDevices/startType API returns 404

### DIFF
--- a/patches/diffs/smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal$2$1.smali.patch
+++ b/patches/diffs/smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal$2$1.smali.patch
@@ -1,0 +1,13 @@
+--- a/smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal$2$1.smali
++++ b/smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal$2$1.smali
+@@ -1091,10 +1091,6 @@
+     :goto_9
+     invoke-virtual {v0}, Ljava/lang/Throwable;->printStackTrace()V
+ 
+-    instance-of v0, v0, Lcom/drake/net/exception/NetUnknownHostException;
+-
+-    if-eqz v0, :cond_14
+-
+     invoke-static {v13}, Lkotlin/coroutines/jvm/internal/Boxing;->a(Z)Ljava/lang/Boolean;
+ 
+     move-result-object v0

--- a/patches/files_to_patch.txt
+++ b/patches/files_to_patch.txt
@@ -162,6 +162,7 @@ smali_classes5/com/xj/landscape/launcher/LandscapeLauncherAppKt.smali
 smali_classes5/com/xj/landscape/launcher/config/EggGameApi.smali
 smali_classes5/com/xj/landscape/launcher/data/mock/MockUtilsKt.smali
 smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper.smali
+smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal$2$1.smali
 smali_classes5/com/xj/landscape/launcher/launcher/strategy/PsRemotePlayLaunchStrategy.smali
 smali_classes5/com/xj/landscape/launcher/router/RouterUtils$checkGuideStep$1.smali
 smali_classes5/com/xj/landscape/launcher/router/RouterUtils.smali


### PR DESCRIPTION
## Summary

`LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal` silently cancels launches on devices that aren't in `DeviceWhiteListManager` and aren't recognized as gamepads when the GameHub backend returns HTTP 404 for `devices/getUnknownDevices` or `/vtouch/startType`. The user sees no error — game cards just don't launch (touch or controller A).

Root cause: the catch block at `:goto_9` only treats `NetUnknownHostException` (no-internet) as recoverable. A 404 response is parsed as the integer `404` by `GsonConverter`, which throws `JSONException` → wrapped as `com.drake.net.exception.ConvertException`. That is not a `NetUnknownHostException`, so the handler returns `false` and the launch is blocked.

This drops the `instance-of` + `if-eqz` pair at `:goto_9` so any caught exception falls through to `return true`, letting the launch proceed with the current settings when the API is unavailable. Behaves identically to the existing no-internet path.

## Device confirmed affected → fixed

- **AYANEO Pocket FIT** (Snapdragon 8 Gen 3 / Adreno 750, Android 14)
- Pre-fix: tapping any game card or pressing A returned to home with no error, only `ConvertException` in logcat
- Post-fix: builds verified, devices launch games normally

## Changes

| File | Change |
|---|---|
| `patches/diffs/smali_classes5/com/xj/landscape/launcher/launcher/LauncherHelper$fetchStartTypeInfoAndSwitchModeInternal$2$1.smali.patch` | New: removes 2 smali instructions at `:goto_9` |
| `patches/files_to_patch.txt` | Adds the new inner-class path |

Net diff: +14 lines, 0 lines of new logic. The Kotlin-equivalent change is:

```diff
 } catch (e: Exception) {
     e.printStackTrace()
-    if (e is NetUnknownHostException) return@withContext true
-    return@withContext false
+    return@withContext true
 }
```

## Test plan

- [x] `./patch.sh` applies cleanly on `apk/GameHub-5.1.0.apk` (md5 `42db8111…`)
- [x] CI `Build Debug APK` workflow green on the branch
- [x] Resulting smali contains `:goto_9` with no `NetUnknownHostException` reference, `:cond_14` label preserved (still referenced by an unrelated branch in the same method)
- [x] Device test on AYANEO Pocket FIT: games launch from cards and controller A
- [ ] Regression check on already-supported devices (whitelisted hardware) — original whitelist-fast-path is untouched

## Notes

This is Option A from the bug report I drafted while diagnosing the issue. Options B (typed exception in `GsonConverter`) and C (whitelist AYANEO devices) are better long-term but out of scope for a smali patcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal error handling logic to streamline control flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Producdevity/gamehub-lite/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->